### PR TITLE
feat(v0.2): Bar Chart + Toggle blocks, icon pickers, confetti, real README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,138 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Zlank
 
-## Getting Started
+No-code builder for Farcaster Snaps. Stack blocks. Hit Deploy. Share to feed.
 
-First, run the development server:
+Live: [zlank.vercel.app](https://zlank.vercel.app)
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+## What it does
+
+Build interactive in-feed Farcaster Snaps without writing code:
+
+1. Open the builder
+2. Pick blocks (header, text, link, music, artist, poll, bar chart, toggle, share, image, divider)
+3. Edit fields inline with a live preview
+4. Hit Deploy - your Snap goes live at `zlank.vercel.app/api/snap/<6-char-id>`
+5. Share to feed - drops it as a cast embed, renders inline in Snap-aware Farcaster clients
+
+Same URL serves:
+- **Snap JSON** to clients that send `Accept: application/vnd.farcaster.snap+json` (renders inline UI in feed)
+- **HTML** with OG tags + `Link rel="alternate"` for everything else (browsers, link previews)
+
+No `fc:miniapp` meta tag - that forces the Mini App embed (image+button) render and prevents inline Snap rendering.
+
+## Block types
+
+| Block | What it does |
+|---|---|
+| **Header** | Title + subtitle in a styled item card |
+| **Text** | Plain text content (max 320 chars) |
+| **Link** | Button with URL + icon picker + primary/secondary variant |
+| **Share** | Compose-cast button with prefilled text + embed |
+| **Image** | HTTPS image with aspect ratio (1:1 / 16:9 / 4:3 / 9:16) |
+| **Music** | Spotify / Tortoise / SoundCloud URL with icon |
+| **Artist** | Farcaster FID + name -> view-profile button |
+| **Poll** | Question + 2-4 options + submit button |
+| **Bar chart** | Up to 6 bars with label + value (data viz) |
+| **Toggle** | Toggle group with 2-6 options, horizontal or vertical |
+| **Divider** | Visual separator |
+
+Plus snap-level **Confetti effect** on render.
+
+## Stack
+
+- **Next.js 16** + React 19 + Tailwind v4
+- **`@farcaster/snap`** v2.1.1 - Snap protocol types + spec
+- **`@farcaster/snap-hono`** v2.0.5 - reference implementation (we use the schemas, ship our own handler)
+- **`@farcaster/miniapp-sdk`** v0.3.0 - Mini App context detection + Quick Auth + composeCast
+- **Vercel Marketplace Redis** (Upstash) - short-ID lookup via `nanoid(6)`
+- **Vercel** - hosting (Hobby tier)
+
+## Architecture
+
+```
+GET /api/snap/[id]
+  - Accept: application/vnd.farcaster.snap+json -> Snap JSON inline render
+  - Accept: text/html (default) -> HTML with OG + Link rel="alternate"
+
+POST /api/snap/[id]
+  - Always returns Snap JSON (for in-snap interactions like vote submit)
+
+POST /api/snaps
+  - Body: { doc: SnapDoc }
+  - Stores in Redis with 6-char nanoid key
+  - Returns: { id, short: true }
+
+GET /s/[id]
+  - HTML viewer page (Mini App webview / browser fallback)
+  - Renders blocks visually for non-Snap-aware clients
+
+GET /api/og/[id]
+  - Dynamic OG image via placehold.co fallback (next/og has Turbopack edge issue)
+
+GET /.well-known/farcaster.json
+  - Mini App manifest (account association placeholder, sign for verified badge)
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+URL convention: 6-char `nanoid` short IDs after first deploy. Old URL-encoded base64 still resolves forever (resolveSnap tries KV first, falls back to base64 decode).
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Local dev
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+npm install
+cp .env.example .env.local
+npm run dev   # http://localhost:3000
+```
 
-## Learn More
+Set `REDIS_URL` in `.env.local` for short URLs (or skip - falls back to base64-encoded URLs).
 
-To learn more about Next.js, take a look at the following resources:
+## Deploy
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+vercel              # link
+vercel --prod       # ship
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+After first deploy, click "Storage" in Vercel project → add Marketplace Redis (free tier 256MB, 10k commands/day) → connect to project. `REDIS_URL` injected automatically.
 
-## Deploy on Vercel
+## Roadmap
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+**Done (v0)**
+- 11 block types + confetti effect
+- Snap protocol + Mini App embed dual-render from same URL
+- Short URLs via Redis
+- Open access (any Farcaster FID can build)
+- Live preview, drag-reorder via up/dn buttons
+- Mini App context detection + Quick Auth fallback
+- CORS for emulator + cross-origin clients
+- OG image with title overlay
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+**Next (v0.5)**
+- Sign In With Farcaster + dashboard
+- Edit existing Snap (stable URL, change blocks, redeploy)
+- Vote tallying for Poll + Toggle blocks (write to Redis)
+- 7-day expiry + paid extension tier
+- Custom domain (zlank.online)
+- Dynamic OG image with logos / charts (when next/og + Turbopack edge fix lands)
+- Mini App account association sign for verified badge + directory listing
+
+**v1**
+- Snap Gallery (public discovery)
+- Cron Snaps (auto-post on schedule)
+- Event-driven Snaps (react to onchain events)
+
+**v2**
+- Token block (Clanker integration)
+- Empire Builder leaderboard block
+- Multi-chain (Base + Solana + Arbitrum)
+- XMTP DMs + Snapshot governance proposals
+- Agent-authored Snaps
+
+## License
+
+MIT
+
+## Acknowledgments
+
+Snap UI patterns inspired by `duodo-snap` and `nouns-snap` (working Snap reference impls). Snap protocol research synthesized from official Farcaster docs + emulator testing.
+
+Built by [@zaal](https://farcaster.xyz/zaal) for the ZAO ecosystem.

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -3,18 +3,28 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { sdk } from '@farcaster/miniapp-sdk';
-import { DEFAULT_SNAP, clampBlock, type SnapDoc, type Block, type BlockType } from '@/lib/blocks';
+import {
+  DEFAULT_SNAP,
+  clampBlock,
+  ICONS,
+  type SnapDoc,
+  type Block,
+  type BlockType,
+  type IconName,
+} from '@/lib/blocks';
 import { encodeSnap } from '@/lib/encode';
 
 const BLOCK_OPTIONS: { type: BlockType; label: string; icon: string }[] = [
   { type: 'header', label: 'Header', icon: 'H' },
   { type: 'text', label: 'Text', icon: 'T' },
-  { type: 'link', label: 'Link button', icon: 'L' },
-  { type: 'share', label: 'Share to feed', icon: 'S' },
+  { type: 'link', label: 'Link', icon: 'L' },
+  { type: 'share', label: 'Share', icon: 'S' },
   { type: 'image', label: 'Image', icon: 'I' },
   { type: 'music', label: 'Music', icon: 'M' },
   { type: 'artist', label: 'Artist', icon: 'A' },
   { type: 'poll', label: 'Poll', icon: 'P' },
+  { type: 'chart', label: 'Bar chart', icon: 'C' },
+  { type: 'toggle', label: 'Toggle', icon: 'G' },
   { type: 'divider', label: 'Divider', icon: '-' },
 ];
 
@@ -25,9 +35,15 @@ function newBlock(type: BlockType): Block {
     case 'text':
       return { type: 'text', content: 'New text block. Edit me.' };
     case 'link':
-      return { type: 'link', label: 'Open link', url: 'https://farcaster.xyz' };
+      return {
+        type: 'link',
+        label: 'Open link',
+        url: 'https://farcaster.xyz',
+        icon: 'external-link',
+        variant: 'primary',
+      };
     case 'share':
-      return { type: 'share', label: 'Share', text: 'Check out this Snap' };
+      return { type: 'share', label: 'Share', text: 'Check out this Snap', icon: 'share' };
     case 'image':
       return {
         type: 'image',
@@ -38,11 +54,28 @@ function newBlock(type: BlockType): Block {
     case 'divider':
       return { type: 'divider' };
     case 'music':
-      return { type: 'music', url: 'https://open.spotify.com/track/', label: 'Listen' };
+      return { type: 'music', url: 'https://open.spotify.com/track/', label: 'Listen', icon: 'play' };
     case 'artist':
       return { type: 'artist', fid: 19640, displayName: 'New artist', label: 'View profile' };
     case 'poll':
       return { type: 'poll', question: 'What should we do next?', options: ['Option A', 'Option B'] };
+    case 'chart':
+      return {
+        type: 'chart',
+        title: 'Top 3',
+        bars: [
+          { label: 'Alice', value: 12 },
+          { label: 'Bob', value: 8 },
+          { label: 'Carol', value: 4 },
+        ],
+      };
+    case 'toggle':
+      return {
+        type: 'toggle',
+        label: 'Pick one',
+        options: ['Yes', 'No', 'Maybe'],
+        orientation: 'horizontal',
+      };
   }
 }
 
@@ -205,6 +238,15 @@ export default function Builder() {
             </select>
           </div>
 
+          <label className="flex items-center gap-2 text-sm text-[#e8eef7] cursor-pointer">
+            <input
+              type="checkbox"
+              checked={doc.confetti ?? false}
+              onChange={(e) => setDoc((d) => ({ ...d, confetti: e.target.checked }))}
+            />
+            Confetti effect on render
+          </label>
+
           <div className="border-t border-[#1f3252] pt-3 space-y-2">
             <h3 className="text-xs text-[#8aa0bd] uppercase tracking-wide">Blocks</h3>
             {doc.blocks.map((block, idx) => (
@@ -340,6 +382,25 @@ function BlockEditor({
             placeholder="https://"
             className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
           />
+          <div className="flex gap-2">
+            <select
+              value={block.icon ?? 'external-link'}
+              onChange={(e) => onChange({ icon: e.target.value as IconName } as Partial<Block>)}
+              className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            >
+              {ICONS.map((i) => (
+                <option key={i} value={i}>{i}</option>
+              ))}
+            </select>
+            <select
+              value={block.variant ?? 'primary'}
+              onChange={(e) => onChange({ variant: e.target.value as 'primary' | 'secondary' } as Partial<Block>)}
+              className="bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            >
+              <option value="primary">primary</option>
+              <option value="secondary">secondary</option>
+            </select>
+          </div>
         </>
       )}
 
@@ -358,6 +419,15 @@ function BlockEditor({
             rows={2}
             className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
           />
+          <select
+            value={block.icon ?? 'share'}
+            onChange={(e) => onChange({ icon: e.target.value as IconName } as Partial<Block>)}
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          >
+            {ICONS.map((i) => (
+              <option key={i} value={i}>{i}</option>
+            ))}
+          </select>
         </>
       )}
 
@@ -402,6 +472,15 @@ function BlockEditor({
             placeholder="Button label (e.g. Listen)"
             className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
           />
+          <select
+            value={block.icon ?? 'play'}
+            onChange={(e) => onChange({ icon: e.target.value as IconName } as Partial<Block>)}
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          >
+            {ICONS.map((i) => (
+              <option key={i} value={i}>{i}</option>
+            ))}
+          </select>
         </>
       )}
 
@@ -433,8 +512,130 @@ function BlockEditor({
         <PollEditor block={block} onChange={onChange} />
       )}
 
+      {block.type === 'chart' && (
+        <ChartEditor block={block} onChange={onChange} />
+      )}
+
+      {block.type === 'toggle' && (
+        <ToggleEditor block={block} onChange={onChange} />
+      )}
+
       {block.type === 'divider' && <p className="text-xs text-[#8aa0bd]">Visual separator. No fields.</p>}
     </div>
+  );
+}
+
+function ChartEditor({
+  block,
+  onChange,
+}: {
+  block: import('@/lib/blocks').ChartBlock;
+  onChange: (patch: Partial<Block>) => void;
+}) {
+  function setBar(i: number, patch: Partial<{ label: string; value: number }>) {
+    const next = block.bars.map((b, j) => (j === i ? { ...b, ...patch } : b));
+    onChange({ bars: next } as Partial<Block>);
+  }
+  function addBar() {
+    if (block.bars.length >= 6) return;
+    onChange({ bars: [...block.bars, { label: 'New', value: 1 }] } as Partial<Block>);
+  }
+  function removeBar(i: number) {
+    if (block.bars.length <= 1) return;
+    onChange({ bars: block.bars.filter((_, j) => j !== i) } as Partial<Block>);
+  }
+  return (
+    <>
+      <input
+        value={block.title}
+        onChange={(e) => onChange({ title: e.target.value } as Partial<Block>)}
+        placeholder="Chart title"
+        className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+      />
+      <div className="space-y-1">
+        {block.bars.map((bar, i) => (
+          <div key={i} className="flex gap-1">
+            <input
+              value={bar.label}
+              onChange={(e) => setBar(i, { label: e.target.value })}
+              placeholder="Label"
+              className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            />
+            <input
+              type="number"
+              value={bar.value}
+              onChange={(e) => setBar(i, { value: Number(e.target.value) })}
+              placeholder="Value"
+              className="w-20 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            />
+            {block.bars.length > 1 && (
+              <button onClick={() => removeBar(i)} className="px-2 text-xs text-red-400 hover:bg-red-900 rounded">x</button>
+            )}
+          </div>
+        ))}
+      </div>
+      {block.bars.length < 6 && (
+        <button onClick={addBar} className="text-xs text-[#f5a623] hover:underline">+ add bar</button>
+      )}
+    </>
+  );
+}
+
+function ToggleEditor({
+  block,
+  onChange,
+}: {
+  block: import('@/lib/blocks').ToggleBlock;
+  onChange: (patch: Partial<Block>) => void;
+}) {
+  function setOption(i: number, value: string) {
+    const next = [...block.options];
+    next[i] = value;
+    onChange({ options: next } as Partial<Block>);
+  }
+  function addOption() {
+    if (block.options.length >= 6) return;
+    onChange({ options: [...block.options, `Option ${block.options.length + 1}`] } as Partial<Block>);
+  }
+  function removeOption(i: number) {
+    if (block.options.length <= 2) return;
+    onChange({ options: block.options.filter((_, j) => j !== i) } as Partial<Block>);
+  }
+  return (
+    <>
+      <input
+        value={block.label}
+        onChange={(e) => onChange({ label: e.target.value } as Partial<Block>)}
+        placeholder="Toggle label"
+        className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+      />
+      <select
+        value={block.orientation ?? 'horizontal'}
+        onChange={(e) => onChange({ orientation: e.target.value as 'horizontal' | 'vertical' } as Partial<Block>)}
+        className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+      >
+        <option value="horizontal">horizontal</option>
+        <option value="vertical">vertical</option>
+      </select>
+      <div className="space-y-1">
+        {block.options.map((opt, i) => (
+          <div key={i} className="flex gap-1">
+            <input
+              value={opt}
+              onChange={(e) => setOption(i, e.target.value)}
+              placeholder={`Option ${i + 1}`}
+              className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            />
+            {block.options.length > 2 && (
+              <button onClick={() => removeOption(i)} className="px-2 text-xs text-red-400 hover:bg-red-900 rounded">x</button>
+            )}
+          </div>
+        ))}
+      </div>
+      {block.options.length < 6 && (
+        <button onClick={addOption} className="text-xs text-[#f5a623] hover:underline">+ add option</button>
+      )}
+    </>
   );
 }
 
@@ -566,6 +767,46 @@ function BlockPreview({ block, theme }: { block: Block; theme: SnapDoc['theme'] 
             <li key={i}>- {opt}</li>
           ))}
         </ul>
+      </div>
+    );
+  }
+  if (block.type === 'chart') {
+    const max = Math.max(...block.bars.map((b) => b.value), 1);
+    return (
+      <div className="bg-[#0a1628] border border-[#1f3252] rounded px-3 py-2 space-y-2">
+        <div className="font-bold text-sm">{block.title}</div>
+        <div className="space-y-1">
+          {block.bars.map((bar, i) => (
+            <div key={i} className="flex items-center gap-2 text-xs">
+              <span className="w-20 truncate text-[#8aa0bd] text-right">{bar.label}</span>
+              <div className="flex-1 h-2 bg-[#1f3252] rounded">
+                <div
+                  className="h-full rounded"
+                  style={{ width: `${(bar.value / max) * 100}%`, background: accent }}
+                />
+              </div>
+              <span className="w-8 text-[#8aa0bd] tabular-nums">{bar.value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+  if (block.type === 'toggle') {
+    return (
+      <div className="bg-[#0a1628] border border-[#1f3252] rounded px-3 py-2 space-y-1">
+        <div className="text-xs text-[#8aa0bd]">{block.label}</div>
+        <div className={block.orientation === 'vertical' ? 'flex flex-col gap-1' : 'flex gap-1'}>
+          {block.options.map((opt, i) => (
+            <span
+              key={i}
+              className="px-2 py-1 bg-[#1f3252] rounded text-xs"
+              style={i === 0 ? { background: accent, color: '#0a1628' } : {}}
+            >
+              {opt}
+            </span>
+          ))}
+        </div>
       </div>
     );
   }

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -1,6 +1,4 @@
 // Block schema for the Zlank builder.
-// Each block represents one piece of a Snap. Builder UI maps to these,
-// renderer (lib/snap-spec.ts) maps these to Snap UI elements.
 
 export type BlockType =
   | 'header'
@@ -11,7 +9,22 @@ export type BlockType =
   | 'divider'
   | 'music'
   | 'artist'
-  | 'poll';
+  | 'poll'
+  | 'chart'
+  | 'toggle';
+
+// Subset of the 34 Snap icons - the most useful for blocks.
+export const ICONS = [
+  'star', 'heart', 'check', 'x', 'info', 'alert-triangle',
+  'arrow-right', 'arrow-left', 'external-link', 'chevron-right', 'refresh-cw',
+  'message-circle', 'repeat', 'share', 'user', 'users',
+  'trophy', 'zap', 'flame', 'gift',
+  'image', 'play', 'pause',
+  'wallet', 'coins',
+  'plus', 'minus', 'bookmark', 'clock',
+  'thumbs-up', 'thumbs-down', 'trending-up', 'trending-down',
+] as const;
+export type IconName = (typeof ICONS)[number];
 
 export interface HeaderBlock {
   type: 'header';
@@ -28,12 +41,15 @@ export interface LinkBlock {
   type: 'link';
   label: string;
   url: string;
+  icon?: IconName;
+  variant?: 'primary' | 'secondary';
 }
 
 export interface ShareBlock {
   type: 'share';
   label: string;
   text: string;
+  icon?: IconName;
 }
 
 export interface ImageBlock {
@@ -51,6 +67,7 @@ export interface MusicBlock {
   type: 'music';
   url: string;
   label: string;
+  icon?: IconName;
 }
 
 export interface ArtistBlock {
@@ -66,6 +83,24 @@ export interface PollBlock {
   options: string[];
 }
 
+export interface ChartBar {
+  label: string;
+  value: number;
+}
+
+export interface ChartBlock {
+  type: 'chart';
+  title: string;
+  bars: ChartBar[];
+}
+
+export interface ToggleBlock {
+  type: 'toggle';
+  label: string;
+  options: string[];
+  orientation?: 'horizontal' | 'vertical';
+}
+
 export type Block =
   | HeaderBlock
   | TextBlock
@@ -75,13 +110,20 @@ export type Block =
   | DividerBlock
   | MusicBlock
   | ArtistBlock
-  | PollBlock;
+  | PollBlock
+  | ChartBlock
+  | ToggleBlock;
+
+export type ThemeAccent =
+  | 'purple' | 'amber' | 'blue' | 'green' | 'red' | 'pink' | 'teal' | 'gray';
 
 export interface SnapDoc {
   version: 1;
   title: string;
-  theme: 'purple' | 'amber' | 'blue' | 'green' | 'red' | 'pink' | 'teal' | 'gray';
+  theme: ThemeAccent;
   blocks: Block[];
+  /** Snap-level effects applied on render. Currently spec supports 'confetti'. */
+  confetti?: boolean;
 }
 
 export const DEFAULT_SNAP: SnapDoc = {
@@ -91,8 +133,8 @@ export const DEFAULT_SNAP: SnapDoc = {
   blocks: [
     { type: 'header', title: 'Hello from Zlank', subtitle: 'A Farcaster Snap built in 30 seconds' },
     { type: 'text', content: 'Edit blocks on the left. Hit Deploy to share to feed.' },
-    { type: 'link', label: 'Visit Zlank', url: 'https://zlank.online' },
-    { type: 'share', label: 'Share', text: 'Just built my first Snap with Zlank' },
+    { type: 'link', label: 'Visit Zlank', url: 'https://zlank.online', icon: 'external-link', variant: 'primary' },
+    { type: 'share', label: 'Share', text: 'Just built my first Snap with Zlank', icon: 'share' },
   ],
 };
 
@@ -106,17 +148,22 @@ const QUESTION_MAX = 200;
 const OPTION_MAX = 60;
 const NAME_MAX = 60;
 const URL_MAX = 2048;
+const CHART_BARS_MAX = 6;
+const TOGGLE_OPTIONS_MAX = 6;
 
 function clampUrl(url: string): string {
   return url.slice(0, URL_MAX);
 }
 
-function clampOptions(options: string[]): string[] {
+function clampOptions(options: string[], minCount = 2, maxCount = 4): string[] {
   const clamped = options.map((o) => o.slice(0, OPTION_MAX));
-  if (clamped.length < 2) {
-    while (clamped.length < 2) clamped.push(`Option ${clamped.length + 1}`);
-  }
-  return clamped.slice(0, 4);
+  while (clamped.length < minCount) clamped.push(`Option ${clamped.length + 1}`);
+  return clamped.slice(0, maxCount);
+}
+
+function clampIcon(icon: IconName | undefined): IconName | undefined {
+  if (!icon) return undefined;
+  return ICONS.includes(icon) ? icon : undefined;
 }
 
 export function clampBlock(block: Block): Block {
@@ -134,12 +181,15 @@ export function clampBlock(block: Block): Block {
         ...block,
         label: block.label.slice(0, LABEL_MAX),
         url: clampUrl(block.url),
+        icon: clampIcon(block.icon),
+        variant: block.variant === 'primary' ? 'primary' : 'secondary',
       };
     case 'share':
       return {
         ...block,
         label: block.label.slice(0, LABEL_MAX),
         text: block.text.slice(0, SHARE_TEXT_MAX),
+        icon: clampIcon(block.icon),
       };
     case 'image':
       return {
@@ -154,6 +204,7 @@ export function clampBlock(block: Block): Block {
         ...block,
         label: block.label.slice(0, LABEL_MAX),
         url: clampUrl(block.url),
+        icon: clampIcon(block.icon),
       };
     case 'artist':
       return {
@@ -166,7 +217,25 @@ export function clampBlock(block: Block): Block {
       return {
         ...block,
         question: block.question.slice(0, QUESTION_MAX),
-        options: clampOptions(block.options),
+        options: clampOptions(block.options, 2, 4),
+      };
+    case 'chart':
+      return {
+        ...block,
+        title: block.title.slice(0, TITLE_MAX),
+        bars: block.bars
+          .slice(0, CHART_BARS_MAX)
+          .map((b) => ({
+            label: String(b.label).slice(0, 40),
+            value: Math.max(0, Number(b.value) || 0),
+          })),
+      };
+    case 'toggle':
+      return {
+        ...block,
+        label: block.label.slice(0, LABEL_MAX),
+        options: clampOptions(block.options, 2, TOGGLE_OPTIONS_MAX),
+        orientation: block.orientation === 'vertical' ? 'vertical' : 'horizontal',
       };
   }
 }

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -1,7 +1,4 @@
-import type { SnapDoc, Block } from './blocks.js';
-
-// Convert Zlank block list into Farcaster Snap UI JSON.
-// Each block becomes 1-3 elements in the ui.elements tree.
+import type { SnapDoc, Block } from './blocks';
 
 interface Element {
   type: string;
@@ -37,18 +34,24 @@ function blockToElements(
       break;
     }
     case 'link': {
+      const props: Record<string, unknown> = { label: block.label };
+      if (block.variant) props.variant = block.variant;
+      if (block.icon) props.icon = block.icon;
+      else props.icon = 'external-link';
       elements[id] = {
         type: 'button',
-        props: { label: block.label, variant: 'primary', icon: 'external-link' },
+        props,
         on: { press: { action: 'open_url', params: { target: block.url } } },
       };
       ids.push(id);
       break;
     }
     case 'share': {
+      const props: Record<string, unknown> = { label: block.label };
+      props.icon = block.icon ?? 'share';
       elements[id] = {
         type: 'button',
-        props: { label: block.label, icon: 'share' },
+        props,
         on: {
           press: {
             action: 'compose_cast',
@@ -75,7 +78,11 @@ function blockToElements(
     case 'music': {
       elements[id] = {
         type: 'button',
-        props: { label: block.label || 'Listen', icon: 'play', variant: 'primary' },
+        props: {
+          label: block.label || 'Listen',
+          icon: block.icon ?? 'play',
+          variant: 'primary',
+        },
         on: { press: { action: 'open_url', params: { target: block.url } } },
       };
       ids.push(id);
@@ -107,7 +114,7 @@ function blockToElements(
       elements[inputId] = {
         type: 'input',
         props: {
-          name: 'vote',
+          name: `vote_${idx}`,
           type: 'text',
           label: 'Your vote',
           placeholder: block.options.join(' / '),
@@ -126,6 +133,35 @@ function blockToElements(
       ids.push(qId, inputId, btnId);
       break;
     }
+    case 'chart': {
+      const titleId = `${id}_title`;
+      const chartId = `${id}_chart`;
+      elements[titleId] = {
+        type: 'text',
+        props: { content: block.title, size: 'md', weight: 'bold' },
+      };
+      elements[chartId] = {
+        type: 'bar_chart',
+        props: {
+          bars: block.bars,
+        },
+      };
+      ids.push(titleId, chartId);
+      break;
+    }
+    case 'toggle': {
+      elements[id] = {
+        type: 'toggle_group',
+        props: {
+          name: `toggle_${idx}`,
+          label: block.label,
+          options: block.options,
+          orientation: block.orientation ?? 'horizontal',
+        },
+      };
+      ids.push(id);
+      break;
+    }
   }
 
   return { ids, elements };
@@ -141,19 +177,24 @@ export function docToSnap(doc: SnapDoc, baseUrl: string) {
     childIds.push(...ids);
   });
 
-  // Wrap blocks in a vertical stack root.
   allElements['page'] = {
     type: 'stack',
     props: { direction: 'vertical', gap: 'md' },
     children: childIds,
   };
 
-  return {
-    version: '1.0' as const,
+  const out: Record<string, unknown> = {
+    version: '1.0',
     theme: { accent: doc.theme },
     ui: {
       root: 'page',
       elements: allElements,
     },
   };
+
+  if (doc.confetti) {
+    out.effects = ['confetti'];
+  }
+
+  return out;
 }


### PR DESCRIPTION
Customization wins for v0.2:

- New Bar Chart block (up to 6 bars, label + value)
- New Toggle block (2-6 options, horizontal/vertical orientation)
- Icon picker on Link / Share / Music blocks (32 icons)
- Variant picker on Link block (primary / secondary)
- Snap-level confetti effect toggle
- Real README (was still default Next.js scaffold)

Now 11 block types total: header / text / link / share / image / music / artist / poll / chart / toggle / divider

Plus snap-level effects: confetti.