### PR TITLE
feat(v0.3): Templates + My Snaps dashboard + Progress/Slider/Switch blocks + Header badge

### DIFF
--- a/app/api/og/[encoded]/route.tsx
+++ b/app/api/og/[encoded]/route.tsx
@@ -20,11 +20,15 @@ export async function GET(
     const direct = decodeSnap(encoded);
     if (direct) {
       title = direct.title;
-      blockCount = direct.blocks.length;
+      // Get block count from first page (or requested page if ?page= is present)
+      const pageParam = new URL(req.url).searchParams.get('page');
+      const pageToShow = pageParam ? direct.pages.find((p) => p.id === pageParam) : direct.pages[0];
+      blockCount = pageToShow?.blocks.length ?? 0;
       accent = themeHex(direct.theme);
     } else if (encoded.length <= 20 && /^[A-Za-z0-9_-]+$/.test(encoded)) {
       const url = new URL(req.url);
-      const snapUrl = `${url.protocol}//${url.host}/api/snap/${encoded}`;
+      const pageParam = url.searchParams.get('page');
+      const snapUrl = `${url.protocol}//${url.host}/api/snap/${encoded}${pageParam ? `?page=${encodeURIComponent(pageParam)}` : ''}`;
       const r = await fetch(snapUrl, {
         headers: { Accept: 'application/vnd.farcaster.snap+json' },
       });

--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -16,10 +16,15 @@ const FALLBACK_DOC: SnapDoc = {
   version: 1,
   title: 'Snap not found',
   theme: 'gray',
-  blocks: [
-    { type: 'header', title: 'Snap not found', subtitle: 'Invalid or expired link' },
-    { type: 'text', content: 'Build your own at zlank.online' },
-    { type: 'link', label: 'Open Zlank', url: 'https://zlank.online' },
+  pages: [
+    {
+      id: 'home',
+      blocks: [
+        { type: 'header', title: 'Snap not found', subtitle: 'Invalid or expired link' },
+        { type: 'text', content: 'Build your own at zlank.online' },
+        { type: 'link', label: 'Open Zlank', url: 'https://zlank.online' },
+      ],
+    },
   ],
 };
 
@@ -42,8 +47,8 @@ const CORS_HEADERS = {
   'Access-Control-Expose-Headers': 'Link, Vary, Content-Type',
 };
 
-function snapJsonResponse(doc: SnapDoc, origin: string, encoded: string): NextResponse {
-  const snap = docToSnap(doc, `${origin}/api/snap/${encoded}`);
+function snapJsonResponse(doc: SnapDoc, origin: string, encoded: string, pageId?: string): NextResponse {
+  const snap = docToSnap(doc, `${origin}/api/snap/${encoded}`, pageId);
   const linkHeader =
     `</api/snap/${encoded}>; rel="alternate"; type="${SNAP_MEDIA_TYPE}", ` +
     `</api/snap/${encoded}>; rel="alternate"; type="text/html"`;
@@ -126,11 +131,12 @@ export async function GET(
   const encoded = await getEncoded(ctx);
   const doc = (await resolveSnap(encoded)) ?? FALLBACK_DOC;
   const origin = getOrigin(req);
+  const pageId = new URL(req.url).searchParams.get('page') ?? undefined;
 
   // Content negotiation: Snap-aware clients ask for the snap media type.
   const accept = req.headers.get('accept') ?? '';
   if (accept.includes(SNAP_MEDIA_TYPE) || accept.includes('vnd.farcaster.snap')) {
-    return snapJsonResponse(doc, origin, encoded);
+    return snapJsonResponse(doc, origin, encoded, pageId);
   }
 
   return htmlResponse(doc, origin, encoded);
@@ -143,7 +149,8 @@ export async function POST(
   const encoded = await getEncoded(ctx);
   const doc = (await resolveSnap(encoded)) ?? FALLBACK_DOC;
   const origin = getOrigin(req);
-  return snapJsonResponse(doc, origin, encoded);
+  const pageId = new URL(req.url).searchParams.get('page') ?? undefined;
+  return snapJsonResponse(doc, origin, encoded, pageId);
 }
 
 function escapeHtml(s: string): string {

--- a/app/api/snap/zlank/route.ts
+++ b/app/api/snap/zlank/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildPromoSnap, ZLANK_SNAP_MEDIA_TYPE } from '@/lib/promo-snap';
+
+// Canonical Zlank promo Snap. Cast zlank.vercel.app and FC clients that fetch
+// /api/snap/zlank get this self-demonstrating Snap.
+
+export const runtime = 'nodejs';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Accept',
+  'Access-Control-Expose-Headers': 'Link, Vary, Content-Type',
+};
+
+function getOrigin(req: NextRequest): string {
+  if (process.env.NEXT_PUBLIC_BASE_URL) return process.env.NEXT_PUBLIC_BASE_URL.replace(/\/$/, '');
+  const proto = req.headers.get('x-forwarded-proto') ?? 'https';
+  const host = req.headers.get('x-forwarded-host') ?? req.headers.get('host') ?? 'zlank.vercel.app';
+  return `${proto}://${host}`;
+}
+
+function snapResponse(req: NextRequest): NextResponse {
+  const origin = getOrigin(req);
+  const snap = buildPromoSnap(origin);
+  return new NextResponse(JSON.stringify(snap), {
+    status: 200,
+    headers: {
+      'Content-Type': `${ZLANK_SNAP_MEDIA_TYPE}; charset=utf-8`,
+      Vary: 'Accept',
+      Link: `</api/snap/zlank>; rel="alternate"; type="${ZLANK_SNAP_MEDIA_TYPE}", </>; rel="alternate"; type="text/html"`,
+      'cache-control': 'public, max-age=300, s-maxage=600',
+      ...CORS_HEADERS,
+    },
+  });
+}
+
+export function GET(req: NextRequest) {
+  return snapResponse(req);
+}
+
+export function POST(req: NextRequest) {
+  return snapResponse(req);
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}

--- a/app/api/snaps/[id]/doc/route.ts
+++ b/app/api/snaps/[id]/doc/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { loadSnapDoc } from '@/lib/kv';
+
+export const runtime = 'nodejs';
+
+export async function GET(
+  _req: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+
+  try {
+    const doc = await loadSnapDoc(id);
+    if (!doc) {
+      return NextResponse.json({ error: 'Snap document not found' }, { status: 404 });
+    }
+    return NextResponse.json(doc);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: 'Failed to load snap document', detail: msg }, { status: 500 });
+  }
+}

--- a/app/api/snaps/route.ts
+++ b/app/api/snaps/route.ts
@@ -15,7 +15,7 @@ interface CreateBody {
 function isSnapDoc(input: unknown): input is SnapDoc {
   if (!input || typeof input !== 'object') return false;
   const d = input as Partial<SnapDoc>;
-  return d.version === 1 && Array.isArray(d.blocks) && typeof d.title === 'string';
+  return d.version === 1 && Array.isArray(d.pages) && typeof d.title === 'string';
 }
 
 export async function POST(req: NextRequest) {

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -28,6 +28,9 @@ const BLOCK_OPTIONS: { type: BlockType; label: string; icon: string }[] = [
   { type: 'poll', label: 'Poll', icon: 'P' },
   { type: 'chart', label: 'Bar chart', icon: 'C' },
   { type: 'toggle', label: 'Toggle', icon: 'G' },
+  { type: 'progress', label: 'Progress', icon: '%' },
+  { type: 'slider', label: 'Slider', icon: '~' },
+  { type: 'switch', label: 'Switch', icon: 'O' },
   { type: 'divider', label: 'Divider', icon: '-' },
 ];
 
@@ -87,6 +90,12 @@ function newBlock(type: BlockType, availablePageIds: string[] = []): Block {
         options: ['Yes', 'No', 'Maybe'],
         orientation: 'horizontal',
       };
+    case 'progress':
+      return { type: 'progress', label: 'Progress to goal', value: 65, max: 100 };
+    case 'slider':
+      return { type: 'slider', label: 'Rate it', min: 0, max: 10, defaultValue: 7 };
+    case 'switch':
+      return { type: 'switch', label: 'Subscribe to updates', defaultChecked: false };
   }
 }
 
@@ -712,6 +721,58 @@ function BlockEditor({
         </>
       )}
 
+      {block.type === 'progress' && (
+        <>
+          <input
+            value={block.label}
+            onChange={(e) => onChange({ label: e.target.value } as Partial<Block>)}
+            placeholder="Label (e.g. Funded)"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <div className="flex gap-2">
+            <input type="number" value={block.value} onChange={(e) => onChange({ value: Number(e.target.value) } as Partial<Block>)} placeholder="value" className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm" />
+            <input type="number" value={block.max} onChange={(e) => onChange({ max: Number(e.target.value) } as Partial<Block>)} placeholder="max" className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm" />
+          </div>
+        </>
+      )}
+      {block.type === 'slider' && (
+        <>
+          <input value={block.label} onChange={(e) => onChange({ label: e.target.value } as Partial<Block>)} placeholder="Label (e.g. Rate)" className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm" />
+          <div className="flex gap-2">
+            <input type="number" value={block.min} onChange={(e) => onChange({ min: Number(e.target.value) } as Partial<Block>)} placeholder="min" className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm" />
+            <input type="number" value={block.max} onChange={(e) => onChange({ max: Number(e.target.value) } as Partial<Block>)} placeholder="max" className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm" />
+            <input type="number" value={block.defaultValue} onChange={(e) => onChange({ defaultValue: Number(e.target.value) } as Partial<Block>)} placeholder="default" className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm" />
+          </div>
+        </>
+      )}
+      {block.type === 'switch' && (
+        <>
+          <input value={block.label} onChange={(e) => onChange({ label: e.target.value } as Partial<Block>)} placeholder="Label" className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm" />
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={block.defaultChecked} onChange={(e) => onChange({ defaultChecked: e.target.checked } as Partial<Block>)} />
+            Default checked
+          </label>
+        </>
+      )}
+      {block.type === 'header' && (
+        <>
+          <input
+            value={block.badgeText ?? ''}
+            onChange={(e) => onChange({ badgeText: e.target.value } as Partial<Block>)}
+            placeholder="Badge text (optional)"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <select
+            value={block.badgeColor ?? 'gray'}
+            onChange={(e) => onChange({ badgeColor: e.target.value as 'green' | 'red' | 'amber' | 'gray' | 'purple' | 'blue' | 'pink' | 'teal' } as Partial<Block>)}
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          >
+            {['gray', 'green', 'amber', 'red', 'purple', 'blue', 'pink', 'teal'].map((c) => (
+              <option key={c} value={c}>badge: {c}</option>
+            ))}
+          </select>
+        </>
+      )}
       {block.type === 'divider' && <p className="text-xs text-[#8aa0bd]">Visual separator. No fields.</p>}
     </div>
   );
@@ -1006,6 +1067,35 @@ function BlockPreview({ block, theme, allPageIds = [] }: { block: Block; theme: 
             </span>
           ))}
         </div>
+      </div>
+    );
+  }
+  if (block.type === 'progress') {
+    const pct = Math.min(100, (block.value / Math.max(1, block.max)) * 100);
+    return (
+      <div className="space-y-1">
+        <div className="text-xs text-[#8aa0bd]">{block.label}</div>
+        <div className="h-2 bg-[#1f3252] rounded">
+          <div className="h-full rounded" style={{ width: `${pct}%`, background: accent }} />
+        </div>
+      </div>
+    );
+  }
+  if (block.type === 'slider') {
+    return (
+      <div className="space-y-1">
+        <div className="text-xs text-[#8aa0bd]">{block.label} ({block.min}-{block.max}, default {block.defaultValue})</div>
+        <input type="range" min={block.min} max={block.max} value={block.defaultValue} readOnly className="w-full" />
+      </div>
+    );
+  }
+  if (block.type === 'switch') {
+    return (
+      <div className="flex items-center justify-between bg-[#0a1628] border border-[#1f3252] rounded px-3 py-2">
+        <span className="text-sm">{block.label}</span>
+        <span className={`px-2 py-0.5 text-xs rounded ${block.defaultChecked ? 'text-[#0a1628]' : 'text-[#8aa0bd]'}`} style={block.defaultChecked ? { background: accent } : { background: '#1f3252' }}>
+          {block.defaultChecked ? 'on' : 'off'}
+        </span>
       </div>
     );
   }

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -13,11 +13,14 @@ import {
   type IconName,
 } from '@/lib/blocks';
 import { encodeSnap } from '@/lib/encode';
+import { saveMySnap } from '@/lib/my-snaps';
+import { getTemplateById } from '@/lib/templates';
 
 const BLOCK_OPTIONS: { type: BlockType; label: string; icon: string }[] = [
   { type: 'header', label: 'Header', icon: 'H' },
   { type: 'text', label: 'Text', icon: 'T' },
   { type: 'link', label: 'Link', icon: 'L' },
+  { type: 'navigate', label: 'Navigate', icon: 'N' },
   { type: 'share', label: 'Share', icon: 'S' },
   { type: 'image', label: 'Image', icon: 'I' },
   { type: 'music', label: 'Music', icon: 'M' },
@@ -28,7 +31,7 @@ const BLOCK_OPTIONS: { type: BlockType; label: string; icon: string }[] = [
   { type: 'divider', label: 'Divider', icon: '-' },
 ];
 
-function newBlock(type: BlockType): Block {
+function newBlock(type: BlockType, availablePageIds: string[] = []): Block {
   switch (type) {
     case 'header':
       return { type: 'header', title: 'New header', subtitle: '' };
@@ -40,6 +43,14 @@ function newBlock(type: BlockType): Block {
         label: 'Open link',
         url: 'https://farcaster.xyz',
         icon: 'external-link',
+        variant: 'primary',
+      };
+    case 'navigate':
+      return {
+        type: 'navigate',
+        label: 'Go to page',
+        pageId: availablePageIds[1] || 'page-2',
+        icon: 'chevron-right',
         variant: 'primary',
       };
     case 'share':
@@ -83,6 +94,9 @@ export default function Builder() {
   const [doc, setDoc] = useState<SnapDoc>(DEFAULT_SNAP);
   const [deployed, setDeployed] = useState<string | null>(null);
   const [isMiniApp, setIsMiniApp] = useState(false);
+  const [currentPageId, setCurrentPageId] = useState<string>('home');
+  const [pageCounter, setPageCounter] = useState(2);
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -93,34 +107,109 @@ export default function Builder() {
       } catch {
         // Browser context, no-op
       }
+
+      // Load from query params (id= for editing existing, template= for template)
+      if (typeof window !== 'undefined') {
+        const params = new URLSearchParams(window.location.search);
+        const snapId = params.get('id');
+        const templateId = params.get('template');
+
+        if (snapId) {
+          // Load existing snap for editing
+          try {
+            const res = await fetch(`/api/snaps/${snapId}/doc`);
+            if (res.ok) {
+              const loaded = (await res.json()) as SnapDoc;
+              setDoc(loaded);
+              setEditingId(snapId);
+            }
+          } catch {
+            // silently fail, stay with default
+          }
+        } else if (templateId) {
+          // Load template
+          const template = getTemplateById(templateId);
+          if (template) {
+            setDoc(template.doc);
+          }
+        }
+      }
     })();
   }, []);
 
   function updateBlock(idx: number, patch: Partial<Block>) {
     setDoc((d) => {
-      const next = [...d.blocks];
-      next[idx] = clampBlock({ ...next[idx], ...patch } as Block);
-      return { ...d, blocks: next };
+      const pageIdx = d.pages.findIndex((p) => p.id === currentPageId);
+      if (pageIdx === -1) return d;
+      const newPages = [...d.pages];
+      const nextBlocks = [...newPages[pageIdx].blocks];
+      nextBlocks[idx] = clampBlock({ ...nextBlocks[idx], ...patch } as Block);
+      newPages[pageIdx] = { ...newPages[pageIdx], blocks: nextBlocks };
+      return { ...d, pages: newPages };
     });
   }
 
   function removeBlock(idx: number) {
-    setDoc((d) => ({ ...d, blocks: d.blocks.filter((_, i) => i !== idx) }));
+    setDoc((d) => {
+      const pageIdx = d.pages.findIndex((p) => p.id === currentPageId);
+      if (pageIdx === -1) return d;
+      const newPages = [...d.pages];
+      newPages[pageIdx] = {
+        ...newPages[pageIdx],
+        blocks: newPages[pageIdx].blocks.filter((_, i) => i !== idx),
+      };
+      return { ...d, pages: newPages };
+    });
   }
 
   function addBlock(type: BlockType) {
-    setDoc((d) => ({ ...d, blocks: [...d.blocks, newBlock(type)] }));
+    setDoc((d) => {
+      const pageIdx = d.pages.findIndex((p) => p.id === currentPageId);
+      if (pageIdx === -1) return d;
+      const newPages = [...d.pages];
+      const otherPageIds = d.pages.filter((p) => p.id !== currentPageId).map((p) => p.id);
+      newPages[pageIdx] = {
+        ...newPages[pageIdx],
+        blocks: [...newPages[pageIdx].blocks, newBlock(type, otherPageIds)],
+      };
+      return { ...d, pages: newPages };
+    });
   }
 
   function moveBlock(idx: number, dir: -1 | 1) {
     setDoc((d) => {
-      const next = [...d.blocks];
+      const pageIdx = d.pages.findIndex((p) => p.id === currentPageId);
+      if (pageIdx === -1) return d;
+      const newPages = [...d.pages];
+      const nextBlocks = [...newPages[pageIdx].blocks];
       const target = idx + dir;
-      if (target < 0 || target >= next.length) return d;
-      [next[idx], next[target]] = [next[target], next[idx]];
-      return { ...d, blocks: next };
+      if (target < 0 || target >= nextBlocks.length) return d;
+      [nextBlocks[idx], nextBlocks[target]] = [nextBlocks[target], nextBlocks[idx]];
+      newPages[pageIdx] = { ...newPages[pageIdx], blocks: nextBlocks };
+      return { ...d, pages: newPages };
     });
   }
+
+  function addPage() {
+    const newPageId = `page-${pageCounter}`;
+    setPageCounter((c) => c + 1);
+    setDoc((d) => ({
+      ...d,
+      pages: [...d.pages, { id: newPageId, blocks: [] }],
+    }));
+    setCurrentPageId(newPageId);
+  }
+
+  function deletePage(pageId: string) {
+    if (doc.pages.length === 1) return;
+    const newPages = doc.pages.filter((p) => p.id !== pageId);
+    setDoc((d) => ({ ...d, pages: newPages }));
+    if (currentPageId === pageId) {
+      setCurrentPageId(newPages[0].id);
+    }
+  }
+
+  const currentPage = doc.pages.find((p) => p.id === currentPageId);
 
   const [deploying, setDeploying] = useState(false);
   const [deployErr, setDeployErr] = useState<string | null>(null);
@@ -140,6 +229,17 @@ export default function Builder() {
       }
       const data = (await res.json()) as { id: string; short: boolean };
       setDeployed(data.id);
+
+      // Save to localStorage for My Snaps history
+      const totalBlockCount = doc.pages.reduce((sum, page) => sum + page.blocks.length, 0);
+      saveMySnap({
+        id: data.id,
+        title: doc.title,
+        theme: doc.theme,
+        blockCount: totalBlockCount,
+        createdAt: editingId ? Date.now() : Date.now(),
+        updatedAt: Date.now(),
+      });
     } catch (err: unknown) {
       // Fall back to URL-encode locally if API call fails
       try {
@@ -181,9 +281,19 @@ export default function Builder() {
   return (
     <main className="min-h-screen flex flex-col">
       <header className="border-b border-[#1f3252] px-4 py-3 flex items-center justify-between">
-        <Link href="/" className="text-[#f5a623] font-bold text-lg">
-          Zlank
-        </Link>
+        <div className="flex items-center gap-4">
+          <Link href="/" className="text-[#f5a623] font-bold text-lg">
+            Zlank
+          </Link>
+          <nav className="hidden sm:flex gap-3 text-sm">
+            <Link href="/templates" className="text-[#8aa0bd] hover:text-[#f5a623] transition">
+              Templates
+            </Link>
+            <Link href="/dashboard" className="text-[#8aa0bd] hover:text-[#f5a623] transition">
+              My Snaps
+            </Link>
+          </nav>
+        </div>
         <div className="flex items-center gap-3">
           {!deployed ? (
             <button
@@ -248,16 +358,53 @@ export default function Builder() {
           </label>
 
           <div className="border-t border-[#1f3252] pt-3 space-y-2">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xs text-[#8aa0bd] uppercase tracking-wide">Pages</h3>
+              <button
+                onClick={addPage}
+                className="text-xs text-[#f5a623] hover:underline"
+              >
+                + add page
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {doc.pages.map((page) => (
+                <div key={page.id} className="flex items-center gap-1">
+                  <button
+                    onClick={() => setCurrentPageId(page.id)}
+                    className={`px-3 py-1 text-xs rounded transition ${
+                      currentPageId === page.id
+                        ? 'bg-[#f5a623] text-[#0a1628]'
+                        : 'bg-[#122440] border border-[#1f3252] text-[#e8eef7] hover:border-[#f5a623]'
+                    }`}
+                  >
+                    {page.id}
+                  </button>
+                  {doc.pages.length > 1 && (
+                    <button
+                      onClick={() => deletePage(page.id)}
+                      className="px-1 text-xs text-red-400 hover:bg-red-900 rounded"
+                    >
+                      x
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="border-t border-[#1f3252] pt-3 space-y-2">
             <h3 className="text-xs text-[#8aa0bd] uppercase tracking-wide">Blocks</h3>
-            {doc.blocks.map((block, idx) => (
+            {currentPage?.blocks.map((block, idx) => (
               <BlockEditor
                 key={idx}
                 block={block}
                 idx={idx}
-                total={doc.blocks.length}
+                total={currentPage.blocks.length}
                 onChange={(patch) => updateBlock(idx, patch)}
                 onRemove={() => removeBlock(idx)}
                 onMove={(dir) => moveBlock(idx, dir)}
+                allPageIds={doc.pages.map((p) => p.id)}
               />
             ))}
           </div>
@@ -280,12 +427,12 @@ export default function Builder() {
         </section>
 
         <section className="p-4 overflow-y-auto">
-          <h3 className="text-xs text-[#8aa0bd] uppercase tracking-wide mb-3">Live preview</h3>
+          <h3 className="text-xs text-[#8aa0bd] uppercase tracking-wide mb-3">Live preview - {currentPageId}</h3>
           <div className="bg-[#122440] border border-[#1f3252] rounded-lg p-4 space-y-3">
-            {doc.blocks.map((b, i) => (
-              <BlockPreview key={i} block={b} theme={doc.theme} />
+            {currentPage?.blocks.map((b, i) => (
+              <BlockPreview key={i} block={b} theme={doc.theme} allPageIds={doc.pages.map((p) => p.id)} />
             ))}
-            {doc.blocks.length === 0 && (
+            {!currentPage?.blocks || currentPage.blocks.length === 0 && (
               <p className="text-[#8aa0bd] text-center py-8">No blocks yet. Add one from the left.</p>
             )}
           </div>
@@ -317,6 +464,7 @@ function BlockEditor({
   onChange,
   onRemove,
   onMove,
+  allPageIds = [],
 }: {
   block: Block;
   idx: number;
@@ -324,6 +472,7 @@ function BlockEditor({
   onChange: (patch: Partial<Block>) => void;
   onRemove: () => void;
   onMove: (dir: -1 | 1) => void;
+  allPageIds?: string[];
 }) {
   return (
     <div className="bg-[#122440] border border-[#1f3252] rounded p-3 space-y-2">
@@ -520,6 +669,49 @@ function BlockEditor({
         <ToggleEditor block={block} onChange={onChange} />
       )}
 
+      {block.type === 'navigate' && (
+        <>
+          <input
+            value={block.label}
+            onChange={(e) => onChange({ label: e.target.value } as Partial<Block>)}
+            placeholder="Button label"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <select
+            value={block.pageId}
+            onChange={(e) => onChange({ pageId: e.target.value } as Partial<Block>)}
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          >
+            {allPageIds
+              .filter((pid) => pid !== 'home') // Can't navigate to current page from this simple impl
+              .map((pid) => (
+                <option key={pid} value={pid}>
+                  {pid}
+                </option>
+              ))}
+          </select>
+          <div className="flex gap-2">
+            <select
+              value={block.icon ?? 'chevron-right'}
+              onChange={(e) => onChange({ icon: e.target.value as IconName } as Partial<Block>)}
+              className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            >
+              {ICONS.map((i) => (
+                <option key={i} value={i}>{i}</option>
+              ))}
+            </select>
+            <select
+              value={block.variant ?? 'primary'}
+              onChange={(e) => onChange({ variant: e.target.value as 'primary' | 'secondary' } as Partial<Block>)}
+              className="bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            >
+              <option value="primary">primary</option>
+              <option value="secondary">secondary</option>
+            </select>
+          </div>
+        </>
+      )}
+
       {block.type === 'divider' && <p className="text-xs text-[#8aa0bd]">Visual separator. No fields.</p>}
     </div>
   );
@@ -703,7 +895,7 @@ function PollEditor({
   );
 }
 
-function BlockPreview({ block, theme }: { block: Block; theme: SnapDoc['theme'] }) {
+function BlockPreview({ block, theme, allPageIds = [] }: { block: Block; theme: SnapDoc['theme']; allPageIds?: string[] }) {
   const accent = `var(--color-zao${theme === 'purple' ? 'purple' : theme === 'amber' ? 'gold' : 'gold'})`;
 
   if (block.type === 'header') {
@@ -722,6 +914,13 @@ function BlockPreview({ block, theme }: { block: Block; theme: SnapDoc['theme'] 
       <a className="block bg-[#0a1628] border border-[#1f3252] rounded px-3 py-2 text-center font-medium hover:border-[#f5a623] transition" style={{ color: accent }}>
         {block.label}
       </a>
+    );
+  }
+  if (block.type === 'navigate') {
+    return (
+      <div className="block bg-[#0a1628] border border-[#1f3252] rounded px-3 py-2 text-center font-medium" style={{ color: accent }}>
+        {block.label}
+      </div>
     );
   }
   if (block.type === 'share') {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { getMySnaps, removeMySnap, clearMySnaps, formatRelativeTime, getThemeColor, type MySnapEntry } from '@/lib/my-snaps';
+
+export default function DashboardPage() {
+  const [snaps, setSnaps] = useState<MySnapEntry[]>([]);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setSnaps(getMySnaps());
+    setMounted(true);
+  }, []);
+
+  function handleDelete(id: string) {
+    removeMySnap(id);
+    setSnaps(getMySnaps());
+  }
+
+  function handleClearAll() {
+    if (typeof window !== 'undefined' && window.confirm('Are you sure? This will clear all saved Snaps from your local storage (server copies remain).')) {
+      clearMySnaps();
+      setSnaps([]);
+    }
+  }
+
+  if (!mounted) return null;
+
+  return (
+    <main className="min-h-screen bg-[#0a1628]">
+      <header className="border-b border-[#1f3252] px-6 py-4">
+        <div className="max-w-6xl mx-auto flex items-center justify-between">
+          <Link href="/" className="text-[#f5a623] font-bold text-lg">
+            Zlank
+          </Link>
+          <Link
+            href="/builder"
+            className="text-sm text-[#e8eef7] hover:text-[#f5a623] transition"
+          >
+            Back to builder
+          </Link>
+        </div>
+      </header>
+
+      <div className="max-w-6xl mx-auto px-6 py-12">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-4xl font-bold text-[#f5a623] mb-2">My Snaps</h1>
+            <p className="text-[#8aa0bd]">{snaps.length} saved snap{snaps.length !== 1 ? 's' : ''}</p>
+          </div>
+          {snaps.length > 0 && (
+            <button
+              onClick={handleClearAll}
+              className="text-sm text-[#8aa0bd] hover:text-red-400 border border-[#1f3252] px-3 py-2 rounded hover:border-red-400 transition"
+            >
+              Clear all
+            </button>
+          )}
+        </div>
+
+        {snaps.length === 0 ? (
+          <div className="bg-[#122440] border border-[#1f3252] rounded-lg p-12 text-center">
+            <p className="text-[#8aa0bd] mb-6">No saved Snaps yet. Build your first one!</p>
+            <Link
+              href="/builder"
+              className="inline-block bg-[#f5a623] text-[#0a1628] font-bold px-6 py-3 rounded hover:bg-[#ffc14d] transition"
+            >
+              Start Building
+            </Link>
+          </div>
+        ) : (
+          <div className="grid gap-4">
+            {snaps.map((snap) => (
+              <SnapCard
+                key={snap.id}
+                snap={snap}
+                onDelete={() => handleDelete(snap.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function SnapCard({ snap, onDelete }: { snap: MySnapEntry; onDelete: () => void }) {
+  return (
+    <div className="bg-[#122440] border border-[#1f3252] rounded-lg p-6 flex items-center justify-between hover:border-[#f5a623] transition">
+      <div className="flex items-center gap-4 flex-1">
+        <div
+          className="w-4 h-4 rounded-full flex-shrink-0"
+          style={{ backgroundColor: getThemeColor(snap.theme) }}
+        />
+        <div className="flex-1 min-w-0">
+          <h3 className="text-lg font-bold text-[#e8eef7] truncate">{snap.title}</h3>
+          <p className="text-sm text-[#8aa0bd]">
+            {snap.blockCount} block{snap.blockCount !== 1 ? 's' : ''} - {formatRelativeTime(snap.updatedAt)}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <a
+          href={`/api/snap/${snap.id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="px-3 py-2 text-sm bg-[#1f3252] text-[#e8eef7] rounded hover:bg-[#2a3f52] transition"
+        >
+          View
+        </a>
+        <Link
+          href={`/builder?id=${snap.id}`}
+          className="px-3 py-2 text-sm bg-[#1f3252] text-[#e8eef7] rounded hover:bg-[#2a3f52] transition"
+        >
+          Edit
+        </Link>
+        <button
+          onClick={onDelete}
+          className="px-3 py-2 text-sm border border-[#1f3252] text-[#8aa0bd] rounded hover:border-red-400 hover:text-red-400 transition"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,58 +3,83 @@ import Link from 'next/link';
 export default function Home() {
   return (
     <main className="max-w-2xl mx-auto px-6 py-16">
-      <h1 className="text-5xl font-bold text-[#f5a623] mb-4">Zlank</h1>
-      <p className="text-xl text-[#8aa0bd] mb-8">
+      <div className="flex items-center gap-3 mb-4">
+        <h1 className="text-5xl font-bold text-[#f5a623]">Zlank</h1>
+        <span className="text-xs px-2 py-0.5 bg-green-500/20 text-green-400 border border-green-500/40 rounded-full font-bold">
+          live
+        </span>
+      </div>
+      <p className="text-xl text-[#8aa0bd] mb-2">
         No-code builder for Farcaster Snaps. Stack blocks. Hit Deploy. Share to feed.
       </p>
+      <p className="text-sm text-[#8aa0bd] mb-8 italic">
+        This page is itself a Snap. Cast{' '}
+        <code className="text-[#f5a623] not-italic">zlank.vercel.app</code>{' '}
+        in Farcaster - it renders inline.
+      </p>
 
-      <div className="flex gap-4">
+      <div className="flex flex-wrap gap-3">
         <Link
           href="/builder"
-          className="inline-block bg-[#f5a623] text-[#0a1628] font-bold px-8 py-4 rounded-lg hover:bg-[#ffc14d] transition"
+          className="inline-block bg-[#f5a623] text-[#0a1628] font-bold px-6 py-3 rounded-lg hover:bg-[#ffc14d] transition"
         >
           Build a Snap
         </Link>
         <Link
           href="/templates"
-          className="inline-block border border-[#f5a623] text-[#f5a623] font-bold px-8 py-4 rounded-lg hover:bg-[#f5a623] hover:text-[#0a1628] transition"
+          className="inline-block border border-[#f5a623] text-[#f5a623] font-bold px-6 py-3 rounded-lg hover:bg-[#f5a623] hover:text-[#0a1628] transition"
         >
           Browse Templates
         </Link>
         <Link
           href="/dashboard"
-          className="inline-block border border-[#8aa0bd] text-[#8aa0bd] font-bold px-8 py-4 rounded-lg hover:border-[#f5a623] hover:text-[#f5a623] transition"
+          className="inline-block border border-[#1f3252] text-[#8aa0bd] font-bold px-6 py-3 rounded-lg hover:border-[#f5a623] hover:text-[#f5a623] transition"
         >
           My Snaps
         </Link>
       </div>
 
       <section className="mt-16 grid gap-4">
-        <h2 className="text-2xl font-bold">Why Zlank</h2>
-        <ul className="space-y-2 text-[#8aa0bd]">
-          <li>- 9 block types (header, text, link, share, image, music, artist, poll, divider)</li>
-          <li>- One-click deploy. Free hosted Snap URL.</li>
-          <li>- Works as a Farcaster Mini App or standalone web</li>
-          <li>- Open source. No whitelist. Any FID can build.</li>
-        </ul>
+        <h2 className="text-2xl font-bold">14 block types</h2>
+        <p className="text-[#8aa0bd]">
+          header, text, link, share, image, music, artist, poll, bar chart, toggle, slider, switch, progress, divider. Plus navigate (multi-page Snaps), confetti effects, theme accents.
+        </p>
+      </section>
+
+      <section className="mt-12 grid gap-4">
+        <h2 className="text-2xl font-bold">8 starter templates</h2>
+        <p className="text-[#8aa0bd]">
+          Fan Vote, Music Drop, Fundraiser, Event RSVP, Top of Week, Two Truths and a Lie, Member Welcome, Quick Poll. Fork in one click, edit, deploy.
+        </p>
       </section>
 
       <section className="mt-12">
         <h2 className="text-2xl font-bold mb-4">How it works</h2>
         <ol className="space-y-2 text-[#8aa0bd] list-decimal list-inside">
-          <li>Open the builder, pick blocks (poll / music / artist / etc)</li>
-          <li>Edit fields inline, see live preview</li>
-          <li>Hit Deploy - your Snap goes live at a hosted URL</li>
-          <li>Share to feed - drops the Snap as a cast embed in Farcaster</li>
+          <li>Open the builder, pick blocks (slider / poll / music / chart)</li>
+          <li>Edit fields inline, watch the live preview</li>
+          <li>Hit Deploy - your Snap is live at a short URL</li>
+          <li>Share to feed - cast renders as inline UI in Snap-aware clients</li>
+          <li>Same URL also serves a Mini App embed for older clients</li>
         </ol>
+      </section>
+
+      <section className="mt-12 p-4 bg-[#122440] border border-[#1f3252] rounded-lg">
+        <p className="text-sm text-[#8aa0bd]">
+          Built for{' '}
+          <a href="https://farhack.xyz/hackathons/farhack-online-2026" className="text-[#f5a623] hover:underline">
+            FarHack Online 2026
+          </a>{' '}
+          - Snaps track. Open source MIT. Any FID, free, no auth.
+        </p>
       </section>
 
       <footer className="mt-16 text-sm text-[#8aa0bd] border-t border-[#1f3252] pt-6">
         Built by{' '}
         <a href="https://farcaster.xyz/zaal" className="text-[#f5a623] hover:underline">
           @zaal
-        </a>{' '}
-        for the ZAO ecosystem. Source on{' '}
+        </a>
+        . Source on{' '}
         <a
           href="https://github.com/bettercallzaal/zlank"
           className="text-[#f5a623] hover:underline"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,12 +8,26 @@ export default function Home() {
         No-code builder for Farcaster Snaps. Stack blocks. Hit Deploy. Share to feed.
       </p>
 
-      <Link
-        href="/builder"
-        className="inline-block bg-[#f5a623] text-[#0a1628] font-bold px-8 py-4 rounded-lg hover:bg-[#ffc14d] transition"
-      >
-        Build a Snap
-      </Link>
+      <div className="flex gap-4">
+        <Link
+          href="/builder"
+          className="inline-block bg-[#f5a623] text-[#0a1628] font-bold px-8 py-4 rounded-lg hover:bg-[#ffc14d] transition"
+        >
+          Build a Snap
+        </Link>
+        <Link
+          href="/templates"
+          className="inline-block border border-[#f5a623] text-[#f5a623] font-bold px-8 py-4 rounded-lg hover:bg-[#f5a623] hover:text-[#0a1628] transition"
+        >
+          Browse Templates
+        </Link>
+        <Link
+          href="/dashboard"
+          className="inline-block border border-[#8aa0bd] text-[#8aa0bd] font-bold px-8 py-4 rounded-lg hover:border-[#f5a623] hover:text-[#f5a623] transition"
+        >
+          My Snaps
+        </Link>
+      </div>
 
       <section className="mt-16 grid gap-4">
         <h2 className="text-2xl font-bold">Why Zlank</h2>

--- a/app/s/[encoded]/page.tsx
+++ b/app/s/[encoded]/page.tsx
@@ -193,5 +193,35 @@ function BlockView({ block, accent, encoded }: { block: Block; accent: string; e
           <p className="text-xs text-[#8aa0bd]">Vote tallying ships in v0.5 with DB.</p>
         </div>
       );
+    case 'progress': {
+      const pct = Math.min(100, (block.value / Math.max(1, block.max)) * 100);
+      return (
+        <div className="space-y-2">
+          <div className="text-sm">{block.label}</div>
+          <div className="h-3 bg-[#1f3252] rounded">
+            <div className="h-full rounded transition-all" style={{ width: `${pct}%`, background: accent }} />
+          </div>
+          <div className="text-xs text-[#8aa0bd]">{block.value} / {block.max}</div>
+        </div>
+      );
+    }
+    case 'slider':
+      return (
+        <div className="space-y-2 bg-[#122440] border border-[#1f3252] rounded-lg px-4 py-3">
+          <div className="text-sm">{block.label}: {block.defaultValue}</div>
+          <input type="range" min={block.min} max={block.max} defaultValue={block.defaultValue} className="w-full" style={{ accentColor: accent }} />
+          <div className="flex justify-between text-xs text-[#8aa0bd]">
+            <span>{block.min}</span>
+            <span>{block.max}</span>
+          </div>
+        </div>
+      );
+    case 'switch':
+      return (
+        <label className="flex items-center justify-between bg-[#122440] border border-[#1f3252] rounded-lg px-4 py-3 cursor-pointer">
+          <span className="text-sm">{block.label}</span>
+          <input type="checkbox" defaultChecked={block.defaultChecked} style={{ accentColor: accent }} />
+        </label>
+      );
   }
 }

--- a/app/s/[encoded]/page.tsx
+++ b/app/s/[encoded]/page.tsx
@@ -11,10 +11,15 @@ const FALLBACK: SnapDoc = {
   version: 1,
   title: 'Snap not found',
   theme: 'gray',
-  blocks: [
-    { type: 'header', title: 'Snap not found', subtitle: 'Invalid or expired link' },
-    { type: 'text', content: 'Build your own at zlank.online' },
-    { type: 'link', label: 'Open Zlank', url: 'https://zlank.online' },
+  pages: [
+    {
+      id: 'home',
+      blocks: [
+        { type: 'header', title: 'Snap not found', subtitle: 'Invalid or expired link' },
+        { type: 'text', content: 'Build your own at zlank.online' },
+        { type: 'link', label: 'Open Zlank', url: 'https://zlank.online' },
+      ],
+    },
   ],
 };
 
@@ -38,16 +43,28 @@ const ACCENT_HEX: Record<SnapDoc['theme'], string> = {
   gray: '#94a3b8',
 };
 
-export default async function SnapViewer({ params }: PageProps) {
+interface SnapViewerProps extends PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function SnapViewer({ params, searchParams }: SnapViewerProps) {
   const { encoded } = await params;
+  const { page: pageParam } = await searchParams;
+  const pageId = typeof pageParam === 'string' ? pageParam : undefined;
+
   const doc = (await resolveSnap(encoded)) ?? FALLBACK;
   const accent = ACCENT_HEX[doc.theme];
+
+  // Get the page to render (default to first page)
+  const currentPageId = pageId || doc.pages[0]?.id;
+  const currentPage = doc.pages.find((p) => p.id === currentPageId);
+  const blocks = currentPage?.blocks ?? doc.pages[0]?.blocks ?? [];
 
   return (
     <main className="max-w-md mx-auto px-4 py-8 min-h-screen flex flex-col">
       <div className="space-y-3 flex-1">
-        {doc.blocks.map((block, i) => (
-          <BlockView key={i} block={block} accent={accent} />
+        {blocks.map((block, i) => (
+          <BlockView key={i} block={block} accent={accent} encoded={encoded} />
         ))}
       </div>
       <footer className="mt-8 pt-4 border-t border-[#1f3252] text-xs text-[#8aa0bd] text-center">
@@ -60,7 +77,7 @@ export default async function SnapViewer({ params }: PageProps) {
   );
 }
 
-function BlockView({ block, accent }: { block: Block; accent: string }) {
+function BlockView({ block, accent, encoded }: { block: Block; accent: string; encoded: string }) {
   switch (block.type) {
     case 'header':
       return (
@@ -84,6 +101,16 @@ function BlockView({ block, accent }: { block: Block; accent: string }) {
         >
           {block.label}
         </a>
+      );
+    case 'navigate':
+      return (
+        <Link
+          href={`/s/${encoded}?page=${encodeURIComponent(block.pageId)}`}
+          className="block bg-[#122440] border rounded-lg px-4 py-3 text-center font-bold hover:bg-[#1a2f4f] transition"
+          style={{ color: accent, borderColor: accent }}
+        >
+          {block.label}
+        </Link>
       );
     case 'share': {
       const params = new URLSearchParams();

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Link from 'next/link';
+import { TEMPLATES, type TemplateMeta } from '@/lib/templates';
+
+export default function TemplatesPage() {
+  return (
+    <main className="min-h-screen bg-[#0a1628]">
+      <header className="border-b border-[#1f3252] px-6 py-4">
+        <div className="max-w-6xl mx-auto">
+          <Link href="/" className="text-[#f5a623] font-bold text-lg">
+            Zlank
+          </Link>
+        </div>
+      </header>
+
+      <div className="max-w-6xl mx-auto px-6 py-12">
+        <h1 className="text-4xl font-bold text-[#f5a623] mb-4">Templates Gallery</h1>
+        <p className="text-[#8aa0bd] mb-12 max-w-2xl">
+          Pick a template below to get started. Each is fully customizable - edit titles, links, colors, and more.
+        </p>
+
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {TEMPLATES.map((template) => (
+            <TemplateCard key={template.id} template={template} />
+          ))}
+        </div>
+
+        <div className="mt-16 pt-8 border-t border-[#1f3252]">
+          <p className="text-[#8aa0bd] text-sm">
+            Not finding what you need? <Link href="/builder" className="text-[#f5a623] hover:underline">Start from scratch</Link>
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function TemplateCard({ template }: { template: TemplateMeta }) {
+  const blockCount = template.doc.pages.reduce((sum, p) => sum + p.blocks.length, 0);
+
+  return (
+    <div className="bg-[#122440] border border-[#1f3252] rounded-lg p-6 flex flex-col hover:border-[#f5a623] transition">
+      <div className="flex-1">
+        <div className="flex items-center gap-2 mb-2">
+          <div
+            className="w-3 h-3 rounded-full"
+            style={{ backgroundColor: getThemeColor(template.doc.theme) }}
+          />
+          <h3 className="text-lg font-bold text-[#e8eef7]">{template.name}</h3>
+        </div>
+        <p className="text-sm text-[#8aa0bd] mb-4">{template.description}</p>
+        <p className="text-xs text-[#8aa0bd] mb-6">{blockCount} block{blockCount !== 1 ? 's' : ''}</p>
+      </div>
+
+      <Link
+        href={`/builder?template=${template.id}`}
+        className="block text-center bg-[#f5a623] text-[#0a1628] font-bold px-4 py-2 rounded hover:bg-[#ffc14d] transition"
+      >
+        Use Template
+      </Link>
+    </div>
+  );
+}
+
+function getThemeColor(theme: string): string {
+  const colors: Record<string, string> = {
+    purple: '#a855f7',
+    amber: '#f59e0b',
+    blue: '#3b82f6',
+    green: '#10b981',
+    red: '#ef4444',
+    pink: '#ec4899',
+    teal: '#14b8a6',
+    gray: '#6b7280',
+  };
+  return colors[theme] || '#f5a623';
+}

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -12,7 +12,10 @@ export type BlockType =
   | 'poll'
   | 'chart'
   | 'toggle'
-  | 'navigate';
+  | 'navigate'
+  | 'progress'
+  | 'slider'
+  | 'switch';
 
 // Subset of the 34 Snap icons - the most useful for blocks.
 export const ICONS = [
@@ -27,10 +30,15 @@ export const ICONS = [
 ] as const;
 export type IconName = (typeof ICONS)[number];
 
+export type BadgeColor =
+  | 'green' | 'red' | 'amber' | 'gray' | 'purple' | 'blue' | 'pink' | 'teal';
+
 export interface HeaderBlock {
   type: 'header';
   title: string;
   subtitle?: string;
+  badgeText?: string;
+  badgeColor?: BadgeColor;
 }
 
 export interface TextBlock {
@@ -110,6 +118,27 @@ export interface NavigateBlock {
   variant?: 'primary' | 'secondary';
 }
 
+export interface ProgressBlock {
+  type: 'progress';
+  label: string;
+  value: number;
+  max: number;
+}
+
+export interface SliderBlock {
+  type: 'slider';
+  label: string;
+  min: number;
+  max: number;
+  defaultValue: number;
+}
+
+export interface SwitchBlock {
+  type: 'switch';
+  label: string;
+  defaultChecked: boolean;
+}
+
 export type Block =
   | HeaderBlock
   | TextBlock
@@ -122,7 +151,10 @@ export type Block =
   | PollBlock
   | ChartBlock
   | ToggleBlock
-  | NavigateBlock;
+  | NavigateBlock
+  | ProgressBlock
+  | SliderBlock
+  | SwitchBlock;
 
 export type ThemeAccent =
   | 'purple' | 'amber' | 'blue' | 'green' | 'red' | 'pink' | 'teal' | 'gray';
@@ -194,6 +226,8 @@ export function clampBlock(block: Block): Block {
         ...block,
         title: block.title.slice(0, TITLE_MAX),
         subtitle: block.subtitle?.slice(0, SUBTITLE_MAX),
+        badgeText: block.badgeText?.slice(0, LABEL_MAX),
+        badgeColor: block.badgeColor,
       };
     case 'text':
       return { ...block, content: block.content.slice(0, TEXT_MAX) };
@@ -265,6 +299,27 @@ export function clampBlock(block: Block): Block {
         pageId: block.pageId.slice(0, 50),
         icon: clampIcon(block.icon),
         variant: block.variant === 'primary' ? 'primary' : 'secondary',
+      };
+    case 'progress':
+      return {
+        ...block,
+        label: block.label.slice(0, LABEL_MAX),
+        value: Math.max(0, Number(block.value) || 0),
+        max: Math.max(1, Number(block.max) || 100),
+      };
+    case 'slider':
+      return {
+        ...block,
+        label: block.label.slice(0, LABEL_MAX),
+        min: Number(block.min) || 0,
+        max: Number(block.max) || 100,
+        defaultValue: Number(block.defaultValue) || 0,
+      };
+    case 'switch':
+      return {
+        ...block,
+        label: block.label.slice(0, LABEL_MAX),
+        defaultChecked: Boolean(block.defaultChecked),
       };
   }
 }

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -11,7 +11,8 @@ export type BlockType =
   | 'artist'
   | 'poll'
   | 'chart'
-  | 'toggle';
+  | 'toggle'
+  | 'navigate';
 
 // Subset of the 34 Snap icons - the most useful for blocks.
 export const ICONS = [
@@ -101,6 +102,14 @@ export interface ToggleBlock {
   orientation?: 'horizontal' | 'vertical';
 }
 
+export interface NavigateBlock {
+  type: 'navigate';
+  label: string;
+  pageId: string;
+  icon?: IconName;
+  variant?: 'primary' | 'secondary';
+}
+
 export type Block =
   | HeaderBlock
   | TextBlock
@@ -112,16 +121,23 @@ export type Block =
   | ArtistBlock
   | PollBlock
   | ChartBlock
-  | ToggleBlock;
+  | ToggleBlock
+  | NavigateBlock;
 
 export type ThemeAccent =
   | 'purple' | 'amber' | 'blue' | 'green' | 'red' | 'pink' | 'teal' | 'gray';
+
+export interface SnapPage {
+  id: string;
+  title?: string;
+  blocks: Block[];
+}
 
 export interface SnapDoc {
   version: 1;
   title: string;
   theme: ThemeAccent;
-  blocks: Block[];
+  pages: SnapPage[];
   /** Snap-level effects applied on render. Currently spec supports 'confetti'. */
   confetti?: boolean;
 }
@@ -130,11 +146,16 @@ export const DEFAULT_SNAP: SnapDoc = {
   version: 1,
   title: 'My Snap',
   theme: 'purple',
-  blocks: [
-    { type: 'header', title: 'Hello from Zlank', subtitle: 'A Farcaster Snap built in 30 seconds' },
-    { type: 'text', content: 'Edit blocks on the left. Hit Deploy to share to feed.' },
-    { type: 'link', label: 'Visit Zlank', url: 'https://zlank.online', icon: 'external-link', variant: 'primary' },
-    { type: 'share', label: 'Share', text: 'Just built my first Snap with Zlank', icon: 'share' },
+  pages: [
+    {
+      id: 'home',
+      blocks: [
+        { type: 'header', title: 'Hello from Zlank', subtitle: 'A Farcaster Snap built in 30 seconds' },
+        { type: 'text', content: 'Edit blocks on the left. Hit Deploy to share to feed.' },
+        { type: 'link', label: 'Visit Zlank', url: 'https://zlank.online', icon: 'external-link', variant: 'primary' },
+        { type: 'share', label: 'Share', text: 'Just built my first Snap with Zlank', icon: 'share' },
+      ],
+    },
   ],
 };
 
@@ -237,5 +258,17 @@ export function clampBlock(block: Block): Block {
         options: clampOptions(block.options, 2, TOGGLE_OPTIONS_MAX),
         orientation: block.orientation === 'vertical' ? 'vertical' : 'horizontal',
       };
+    case 'navigate':
+      return {
+        ...block,
+        label: block.label.slice(0, LABEL_MAX),
+        pageId: block.pageId.slice(0, 50),
+        icon: clampIcon(block.icon),
+        variant: block.variant === 'primary' ? 'primary' : 'secondary',
+      };
   }
+}
+
+export function getPageIds(doc: SnapDoc): string[] {
+  return doc.pages.map((p) => p.id);
 }

--- a/lib/encode.ts
+++ b/lib/encode.ts
@@ -1,4 +1,4 @@
-import type { SnapDoc } from './blocks.js';
+import type { SnapDoc, Block } from './blocks.js';
 
 // base64url encode a Snap doc into the URL slug.
 // No DB v0 - the snap config IS the URL.
@@ -14,10 +14,50 @@ export function decodeSnap(encoded: string): SnapDoc | null {
     const padded = encoded.replace(/-/g, '+').replace(/_/g, '/');
     const padding = padded.length % 4 === 0 ? '' : '='.repeat(4 - (padded.length % 4));
     const json = Buffer.from(padded + padding, 'base64').toString('utf8');
-    const doc = JSON.parse(json);
-    if (doc?.version !== 1 || !Array.isArray(doc.blocks)) return null;
-    return doc as SnapDoc;
+    const raw = JSON.parse(json);
+    if (raw?.version !== 1) return null;
+
+    // Migrate old single-page format (blocks array) to new multi-page format
+    const doc = migrateSnapDoc(raw);
+    return doc;
   } catch {
     return null;
   }
+}
+
+function migrateSnapDoc(raw: unknown): SnapDoc | null {
+  if (typeof raw !== 'object' || raw === null) return null;
+
+  const doc = raw as Record<string, unknown>;
+
+  if (!doc.version || doc.version !== 1 || !doc.title || !doc.theme) return null;
+
+  // Old format has doc.blocks (array)
+  if (Array.isArray(doc.blocks)) {
+    return {
+      version: 1,
+      title: String(doc.title),
+      theme: doc.theme as SnapDoc['theme'],
+      pages: [
+        {
+          id: 'home',
+          blocks: doc.blocks as Block[],
+        },
+      ],
+      confetti: doc.confetti as boolean | undefined,
+    };
+  }
+
+  // New format has doc.pages (array of SnapPage)
+  if (Array.isArray(doc.pages)) {
+    return {
+      version: 1,
+      title: String(doc.title),
+      theme: doc.theme as SnapDoc['theme'],
+      pages: doc.pages as SnapDoc['pages'],
+      confetti: doc.confetti as boolean | undefined,
+    };
+  }
+
+  return null;
 }

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -36,6 +36,7 @@ export function isKvAvailable(): boolean {
 }
 
 const KEY_PREFIX = 'snap:';
+const SNAPDOC_PREFIX = 'snapdoc:';
 const SHORT_ID_LEN = 6;
 
 export async function saveSnap(doc: SnapDoc): Promise<string> {
@@ -47,10 +48,13 @@ export async function saveSnap(doc: SnapDoc): Promise<string> {
     const exists = await c.exists(key);
     if (exists) continue;
     await c.set(key, JSON.stringify(doc));
+    // Also store the original SnapDoc for editing
+    await c.set(SNAPDOC_PREFIX + id, JSON.stringify(doc));
     return id;
   }
   const id = nanoid(SHORT_ID_LEN + 4);
   await c.set(KEY_PREFIX + id, JSON.stringify(doc));
+  await c.set(SNAPDOC_PREFIX + id, JSON.stringify(doc));
   return id;
 }
 
@@ -58,6 +62,18 @@ export async function loadSnap(id: string): Promise<SnapDoc | null> {
   const c = await getClient();
   if (!c) return null;
   const raw = await c.get(KEY_PREFIX + id);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as SnapDoc;
+  } catch {
+    return null;
+  }
+}
+
+export async function loadSnapDoc(id: string): Promise<SnapDoc | null> {
+  const c = await getClient();
+  if (!c) return null;
+  const raw = await c.get(SNAPDOC_PREFIX + id);
   if (!raw) return null;
   try {
     return JSON.parse(raw) as SnapDoc;

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -58,13 +58,43 @@ export async function saveSnap(doc: SnapDoc): Promise<string> {
   return id;
 }
 
+function migrateLoadedDoc(raw: unknown): SnapDoc | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const d = raw as Record<string, unknown>;
+  if (d.version !== 1 || typeof d.title !== 'string') return null;
+
+  // Old single-page format: has blocks array on root
+  if (Array.isArray(d.blocks)) {
+    return {
+      version: 1,
+      title: d.title,
+      theme: (d.theme as SnapDoc['theme']) ?? 'purple',
+      pages: [{ id: 'home', blocks: d.blocks as SnapDoc['pages'][number]['blocks'] }],
+      confetti: d.confetti as boolean | undefined,
+    };
+  }
+
+  // New multi-page format
+  if (Array.isArray(d.pages)) {
+    return {
+      version: 1,
+      title: d.title,
+      theme: (d.theme as SnapDoc['theme']) ?? 'purple',
+      pages: d.pages as SnapDoc['pages'],
+      confetti: d.confetti as boolean | undefined,
+    };
+  }
+
+  return null;
+}
+
 export async function loadSnap(id: string): Promise<SnapDoc | null> {
   const c = await getClient();
   if (!c) return null;
   const raw = await c.get(KEY_PREFIX + id);
   if (!raw) return null;
   try {
-    return JSON.parse(raw) as SnapDoc;
+    return migrateLoadedDoc(JSON.parse(raw));
   } catch {
     return null;
   }
@@ -76,7 +106,7 @@ export async function loadSnapDoc(id: string): Promise<SnapDoc | null> {
   const raw = await c.get(SNAPDOC_PREFIX + id);
   if (!raw) return null;
   try {
-    return JSON.parse(raw) as SnapDoc;
+    return migrateLoadedDoc(JSON.parse(raw));
   } catch {
     return null;
   }

--- a/lib/my-snaps.ts
+++ b/lib/my-snaps.ts
@@ -1,0 +1,90 @@
+// localStorage-backed helpers for My Snaps feature (no auth required)
+
+export interface MySnapEntry {
+  id: string;
+  title: string;
+  theme: string;
+  blockCount: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+const STORAGE_KEY = 'zlank:my-snaps';
+const MAX_SNAPS = 50;
+
+export function getMySnaps(): MySnapEntry[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as MySnapEntry[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveMySnap(entry: MySnapEntry): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const snaps = getMySnaps();
+    const existing = snaps.findIndex((s) => s.id === entry.id);
+    if (existing >= 0) {
+      snaps[existing] = { ...snaps[existing], ...entry, updatedAt: Date.now() };
+    } else {
+      snaps.unshift(entry);
+    }
+    const trimmed = snaps.slice(0, MAX_SNAPS);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+  } catch {
+    // silently fail
+  }
+}
+
+export function removeMySnap(id: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const snaps = getMySnaps().filter((s) => s.id !== id);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(snaps));
+  } catch {
+    // silently fail
+  }
+}
+
+export function clearMySnaps(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // silently fail
+  }
+}
+
+export function formatRelativeTime(timestamp: number): string {
+  const now = Date.now();
+  const diff = now - timestamp;
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (seconds < 60) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+export function getThemeColor(theme: string): string {
+  const themeColors: Record<string, string> = {
+    purple: '#a855f7',
+    amber: '#f59e0b',
+    blue: '#3b82f6',
+    green: '#10b981',
+    red: '#ef4444',
+    pink: '#ec4899',
+    teal: '#14b8a6',
+    gray: '#6b7280',
+  };
+  return themeColors[theme] || '#f5a623';
+}

--- a/lib/promo-snap.ts
+++ b/lib/promo-snap.ts
@@ -1,0 +1,79 @@
+// The Zlank promo Snap - what cast embeds of zlank.vercel.app render as.
+// Self-demonstrating: the homepage IS a Snap that shows what Zlank does.
+
+const SNAP_MEDIA_TYPE = 'application/vnd.farcaster.snap+json';
+
+export function buildPromoSnap(origin: string) {
+  return {
+    version: '1.0' as const,
+    theme: { accent: 'amber' as const },
+    ui: {
+      root: 'page',
+      elements: {
+        page: {
+          type: 'stack',
+          props: { direction: 'vertical', gap: 'md' },
+          children: ['header', 'desc', 'sep1', 'features', 'sep2', 'btn_build', 'btn_templates', 'btn_github', 'btn_share'],
+        },
+        header: {
+          type: 'item',
+          props: {
+            title: 'Zlank',
+            description: 'No-code builder for Farcaster Snaps',
+          },
+          children: ['badge'],
+        },
+        badge: {
+          type: 'badge',
+          props: { label: 'live', color: 'green' },
+        },
+        desc: {
+          type: 'text',
+          props: {
+            content: 'Stack 14 block types. Hit Deploy. Share to feed. Cast renders as inline UI in Snap-aware clients.',
+            size: 'md',
+          },
+        },
+        sep1: { type: 'separator', props: {} },
+        features: {
+          type: 'text',
+          props: {
+            content: '14 blocks. 8 templates. Multi-page. Confetti. Open source. Any FID.',
+            size: 'sm',
+          },
+        },
+        sep2: { type: 'separator', props: {} },
+        btn_build: {
+          type: 'button',
+          props: { label: 'Build a Snap', variant: 'primary', icon: 'plus' },
+          on: { press: { action: 'open_url', params: { target: `${origin}/builder` } } },
+        },
+        btn_templates: {
+          type: 'button',
+          props: { label: 'Browse templates', icon: 'star' },
+          on: { press: { action: 'open_url', params: { target: `${origin}/templates` } } },
+        },
+        btn_github: {
+          type: 'button',
+          props: { label: 'GitHub', icon: 'external-link' },
+          on: { press: { action: 'open_url', params: { target: 'https://github.com/bettercallzaal/zlank' } } },
+        },
+        btn_share: {
+          type: 'button',
+          props: { label: 'Share Zlank', icon: 'share' },
+          on: {
+            press: {
+              action: 'compose_cast',
+              params: {
+                text: 'no-code Farcaster Snap builder. stack blocks > deploy > share to feed',
+                embeds: [origin],
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+export const ZLANK_SNAP_MEDIA_TYPE = SNAP_MEDIA_TYPE;

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -18,11 +18,22 @@ function blockToElements(
 
   switch (block.type) {
     case 'header': {
-      elements[id] = {
+      const itemId = id;
+      const childIds: string[] = [];
+      if (block.badgeText) {
+        const badgeId = `${id}_badge`;
+        elements[badgeId] = {
+          type: 'badge',
+          props: { label: block.badgeText, color: block.badgeColor ?? 'gray' },
+        };
+        childIds.push(badgeId);
+      }
+      elements[itemId] = {
         type: 'item',
         props: { title: block.title, description: block.subtitle ?? '' },
+        ...(childIds.length ? { children: childIds } : {}),
       };
-      ids.push(id);
+      ids.push(itemId);
       break;
     }
     case 'text': {
@@ -171,6 +182,40 @@ function blockToElements(
         type: 'button',
         props,
         on: { press: { action: 'submit', params: { target: `${baseUrl}?page=${encodeURIComponent(block.pageId)}` } } },
+      };
+      ids.push(id);
+      break;
+    }
+    case 'progress': {
+      elements[id] = {
+        type: 'progress',
+        props: { value: block.value, max: block.max, label: block.label },
+      };
+      ids.push(id);
+      break;
+    }
+    case 'slider': {
+      elements[id] = {
+        type: 'slider',
+        props: {
+          name: `slider_${idx}`,
+          label: block.label,
+          min: block.min,
+          max: block.max,
+          defaultValue: block.defaultValue,
+        },
+      };
+      ids.push(id);
+      break;
+    }
+    case 'switch': {
+      elements[id] = {
+        type: 'switch',
+        props: {
+          name: `switch_${idx}`,
+          label: block.label,
+          defaultChecked: block.defaultChecked,
+        },
       };
       ids.push(id);
       break;

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -162,16 +162,38 @@ function blockToElements(
       ids.push(id);
       break;
     }
+    case 'navigate': {
+      const props: Record<string, unknown> = { label: block.label };
+      if (block.variant) props.variant = block.variant;
+      if (block.icon) props.icon = block.icon;
+      else props.icon = 'chevron-right';
+      elements[id] = {
+        type: 'button',
+        props,
+        on: { press: { action: 'submit', params: { target: `${baseUrl}?page=${encodeURIComponent(block.pageId)}` } } },
+      };
+      ids.push(id);
+      break;
+    }
   }
 
   return { ids, elements };
 }
 
-export function docToSnap(doc: SnapDoc, baseUrl: string) {
+export function docToSnap(doc: SnapDoc, baseUrl: string, pageId?: string) {
+  // Default to first page if not specified
+  const targetPage = pageId || doc.pages[0]?.id;
+  const page = doc.pages.find((p) => p.id === targetPage);
+
+  if (!page) {
+    // Fallback: render first page if requested page not found
+    return docToSnap(doc, baseUrl, doc.pages[0]?.id);
+  }
+
   const allElements: Record<string, Element> = {};
   const childIds: string[] = [];
 
-  doc.blocks.forEach((block, idx) => {
+  page.blocks.forEach((block, idx) => {
     const { ids, elements } = blockToElements(block, idx, baseUrl);
     Object.assign(allElements, elements);
     childIds.push(...ids);

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -244,6 +244,25 @@ export function docToSnap(doc: SnapDoc, baseUrl: string, pageId?: string) {
     childIds.push(...ids);
   });
 
+  // Auto-append "Built with Zlank" footer to every Snap (viral attribution).
+  // Skipped on the promo Snap itself (handled separately in /api/snap/zlank).
+  const homepageOrigin = (() => {
+    try {
+      return new URL(baseUrl).origin;
+    } catch {
+      return 'https://zlank.vercel.app';
+    }
+  })();
+  allElements['_zlank_sep'] = { type: 'separator', props: {} };
+  allElements['_zlank_footer'] = {
+    type: 'button',
+    props: { label: 'zlank.online', icon: 'star' },
+    on: {
+      press: { action: 'open_url', params: { target: homepageOrigin } },
+    },
+  };
+  childIds.push('_zlank_sep', '_zlank_footer');
+
   allElements['page'] = {
     type: 'stack',
     props: { direction: 'vertical', gap: 'md' },

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -1,0 +1,327 @@
+import type { SnapDoc } from './blocks';
+
+export interface TemplateMeta {
+  id: string;
+  name: string;
+  description: string;
+  doc: SnapDoc;
+}
+
+export const TEMPLATES: TemplateMeta[] = [
+  {
+    id: 'fan-vote',
+    name: 'Fan Vote',
+    description: 'Header, poll, and share button for quick voting',
+    doc: {
+      version: 1,
+      title: 'Fan Vote',
+      theme: 'purple',
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'What should we do next?',
+              subtitle: 'Cast your vote below',
+            },
+            {
+              type: 'poll',
+              question: 'Pick your favorite option',
+              options: ['Option A', 'Option B', 'Option C'],
+            },
+            {
+              type: 'share',
+              label: 'Share vote',
+              text: 'Just voted on this poll',
+              icon: 'share',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'music-drop',
+    name: 'Music Drop',
+    description: 'Announce a new track with artist and share',
+    doc: {
+      version: 1,
+      title: 'Music Drop',
+      theme: 'amber',
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'New Track Released',
+              subtitle: 'Available now on all platforms',
+            },
+            {
+              type: 'music',
+              url: 'https://open.spotify.com/track/',
+              label: 'Listen on Spotify',
+              icon: 'play',
+            },
+            {
+              type: 'artist',
+              fid: 19640,
+              displayName: 'Artist Name',
+              label: 'View Artist',
+            },
+            {
+              type: 'share',
+              label: 'Share Track',
+              text: 'Just dropped a new track',
+              icon: 'share',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'fundraiser',
+    name: 'Fundraiser',
+    description: 'Progress chart for fundraising campaign',
+    doc: {
+      version: 1,
+      title: 'Fundraiser',
+      theme: 'green',
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'Support Our Mission',
+              subtitle: 'Help us reach our goal',
+            },
+            {
+              type: 'chart',
+              title: 'Top Supporters',
+              bars: [
+                { label: 'Alice', value: 50 },
+                { label: 'Bob', value: 30 },
+                { label: 'Carol', value: 20 },
+              ],
+            },
+            {
+              type: 'link',
+              label: 'Contribute Now',
+              url: 'https://example.com/donate',
+              icon: 'gift',
+              variant: 'primary',
+            },
+            {
+              type: 'share',
+              label: 'Share',
+              text: 'Supporting this cause',
+              icon: 'share',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'event-rsvp',
+    name: 'Event RSVP',
+    description: 'Simple event announcement with RSVP link',
+    doc: {
+      version: 1,
+      title: 'Event RSVP',
+      theme: 'blue',
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'You are Invited',
+              subtitle: 'Join us for an unforgettable evening',
+            },
+            {
+              type: 'text',
+              content: 'Date: Saturday, May 15\nTime: 7:00 PM - 11:00 PM\nLocation: Main Event Space',
+            },
+            {
+              type: 'link',
+              label: 'RSVP Now',
+              url: 'https://example.com/rsvp',
+              icon: 'external-link',
+              variant: 'primary',
+            },
+            {
+              type: 'share',
+              label: 'Share Event',
+              text: 'Going to this event',
+              icon: 'share',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'top-of-week',
+    name: 'Top of the Week',
+    description: 'Showcase top weekly performers',
+    doc: {
+      version: 1,
+      title: 'Top of the Week',
+      theme: 'amber',
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'This Week Top 7',
+              subtitle: 'The hottest performers this week',
+            },
+            {
+              type: 'chart',
+              title: 'Weekly Leaderboard',
+              bars: [
+                { label: 'Artist 1', value: 95 },
+                { label: 'Artist 2', value: 87 },
+                { label: 'Artist 3', value: 76 },
+                { label: 'Artist 4', value: 65 },
+                { label: 'Artist 5', value: 54 },
+                { label: 'Artist 6', value: 43 },
+                { label: 'Artist 7', value: 32 },
+              ],
+            },
+            {
+              type: 'share',
+              label: 'Share Leaderboard',
+              text: 'Check out this week top performers',
+              icon: 'share',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'two-truths-lie',
+    name: 'Two Truths and a Lie',
+    description: 'Interactive game with confetti reveal',
+    doc: {
+      version: 1,
+      title: 'Two Truths and a Lie',
+      theme: 'pink',
+      confetti: true,
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'Two Truths and a Lie',
+              subtitle: 'Guess which one is false',
+            },
+            {
+              type: 'toggle',
+              label: 'Pick one statement',
+              options: ['Statement 1', 'Statement 2', 'Statement 3'],
+              orientation: 'vertical',
+            },
+            {
+              type: 'share',
+              label: 'Share Game',
+              text: 'Playing two truths and a lie',
+              icon: 'share',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'member-welcome',
+    name: 'Member Welcome',
+    description: 'Onboard new members with links',
+    doc: {
+      version: 1,
+      title: 'Welcome to the Community',
+      theme: 'teal',
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'Welcome Aboard',
+              subtitle: 'Glad to have you on the team',
+            },
+            {
+              type: 'text',
+              content: 'Here are some helpful resources to get you started:',
+            },
+            {
+              type: 'link',
+              label: 'Read the Handbook',
+              url: 'https://example.com/handbook',
+              icon: 'external-link',
+              variant: 'primary',
+            },
+            {
+              type: 'link',
+              label: 'Join Discord',
+              url: 'https://discord.gg/example',
+              icon: 'external-link',
+              variant: 'primary',
+            },
+            {
+              type: 'link',
+              label: 'View Roadmap',
+              url: 'https://example.com/roadmap',
+              icon: 'external-link',
+              variant: 'primary',
+            },
+            {
+              type: 'share',
+              label: 'Share Welcome',
+              text: 'Just joined this amazing community',
+              icon: 'share',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'quick-poll',
+    name: 'Quick Poll',
+    description: 'Simple header and poll combo',
+    doc: {
+      version: 1,
+      title: 'Quick Poll',
+      theme: 'red',
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'Quick Poll',
+              subtitle: 'What is your preference?',
+            },
+            {
+              type: 'poll',
+              question: 'Choose one',
+              options: ['Yes', 'No'],
+            },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+export function getTemplateById(id: string): TemplateMeta | undefined {
+  return TEMPLATES.find((t) => t.id === id);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const SNAP_MEDIA_TYPE = 'application/vnd.farcaster.snap+json';
+
+// Make the homepage self-demonstrating: when a Snap-aware Farcaster client
+// fetches zlank.vercel.app with Accept: application/vnd.farcaster.snap+json,
+// rewrite to /api/snap/zlank which returns the Zlank promo Snap. Browsers
+// (Accept: text/html) continue to the React landing page.
+
+export function middleware(req: NextRequest) {
+  if (req.nextUrl.pathname !== '/') return NextResponse.next();
+  const accept = req.headers.get('accept') ?? '';
+  if (accept.includes(SNAP_MEDIA_TYPE) || accept.includes('vnd.farcaster.snap')) {
+    return NextResponse.rewrite(new URL('/api/snap/zlank', req.url));
+  }
+  // Browser path - inject Link header so Snap-aware crawlers can discover
+  // the Snap alternate representation.
+  const res = NextResponse.next();
+  res.headers.set(
+    'Link',
+    `</api/snap/zlank>; rel="alternate"; type="${SNAP_MEDIA_TYPE}"`,
+  );
+  res.headers.set('Vary', 'Accept');
+  return res;
+}
+
+export const config = {
+  matcher: '/',
+};


### PR DESCRIPTION
Combines 3 batches of work that were orphaned on the merged PR #7 branch:

**Templates Gallery** (/templates) - 8 starter Snaps (Fan Vote, Music Drop, Fundraiser, Event RSVP, Top of Week, Two Truths and a Lie, Member Welcome, Quick Poll). Builder accepts ?template= query param to load.

**My Snaps Dashboard** (/dashboard) - localStorage-backed history. View / Edit / Delete actions. Edit loads existing snap back into builder via ?id= and new GET /api/snaps/[id]/doc endpoint that returns the original SnapDoc from Redis.

**14 block types now** (added Progress, Slider, Switch). Header block extended with optional badge (text + 8 colors).

Production was deployed from the orphaned branch directly via vercel --prod, so live state matches this PR. This PR brings main back in sync.

Note: 3 commits pushed to merged-PR branch were orphaned. Cherry-picked onto fresh branch off main.