### PR TITLE
feat(gates): token-balance-gated blocks (Build 1, doc 527)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Vercel marketplace Redis (TCP). Set automatically when you add the
+# Upstash/Vercel KV integration in the project.
+REDIS_URL=
+
+# Optional: Neynar API key for token-gated blocks (FID -> verified address).
+# Without this, gated blocks always render as locked stubs.
+# Get one at https://neynar.com.
+NEYNAR_API_KEY=
+
+# Optional: Base mainnet RPC URL for ERC-20 balanceOf reads on token gates.
+# Defaults to the public Base RPC when unset.
+BASE_RPC_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -3,6 +3,7 @@ import { parseRequest } from '@farcaster/snap/server';
 import { resolveSnap } from '@/lib/resolve-snap';
 import { docToSnap } from '@/lib/snap-spec';
 import { recordVote } from '@/lib/kv';
+import { evaluateGates, isGateRule, type GateResult } from '@/lib/gates';
 import type { SnapDoc, Block, ChartBar } from '@/lib/blocks';
 
 export const runtime = 'nodejs';
@@ -49,8 +50,35 @@ const CORS_HEADERS = {
   'Access-Control-Expose-Headers': 'Link, Vary, Content-Type',
 };
 
-function snapJsonResponse(doc: SnapDoc, origin: string, encoded: string, pageId?: string): NextResponse {
-  const snap = docToSnap(doc, `${origin}/api/snap/${encoded}`, pageId);
+async function resolveGatesForPage(
+  doc: SnapDoc,
+  pageId: string | undefined,
+  fid: number | undefined,
+): Promise<Map<number, GateResult> | undefined> {
+  const targetId = pageId || doc.pages[0]?.id;
+  const page = doc.pages.find((p) => p.id === targetId);
+  if (!page) return undefined;
+  const rules = page.blocks
+    .map((block, idx) => ({ idx, rule: block.gate }))
+    .filter(
+      (entry): entry is { idx: number; rule: NonNullable<typeof entry.rule> } =>
+        isGateRule(entry.rule),
+    );
+  if (rules.length === 0) return undefined;
+  return evaluateGates(rules, { fid });
+}
+
+function snapJsonResponse(
+  doc: SnapDoc,
+  origin: string,
+  encoded: string,
+  pageId?: string,
+  gateResults?: Map<number, GateResult>,
+): NextResponse {
+  const snap = docToSnap(doc, `${origin}/api/snap/${encoded}`, {
+    pageId,
+    gateResults,
+  });
   const linkHeader =
     `</api/snap/${encoded}>; rel="alternate"; type="${SNAP_MEDIA_TYPE}", ` +
     `</api/snap/${encoded}>; rel="alternate"; type="text/html"`;
@@ -138,7 +166,9 @@ export async function GET(
   // Content negotiation: Snap-aware clients ask for the snap media type.
   const accept = req.headers.get('accept') ?? '';
   if (accept.includes(SNAP_MEDIA_TYPE) || accept.includes('vnd.farcaster.snap')) {
-    return snapJsonResponse(doc, origin, encoded, pageId);
+    // GET has no FID; gated blocks render as locked stubs.
+    const gateResults = await resolveGatesForPage(doc, pageId, undefined);
+    return snapJsonResponse(doc, origin, encoded, pageId, gateResults);
   }
 
   return htmlResponse(doc, origin, encoded);
@@ -153,35 +183,46 @@ export async function POST(
   const origin = getOrigin(req);
   const pageId = new URL(req.url).searchParams.get('page') ?? undefined;
 
-  // Parse the JFS POST body to extract user inputs (poll vote, slider value,
-  // switch state, toggle selection). On any vote_X input, record + return a
-  // results Snap with bar chart of tallies + confetti.
+  // Parse JFS POST body for inputs + the viewer's FID (used for gate eval).
   let inputs: Record<string, unknown> = {};
+  let fid: number | undefined;
   try {
     const parsed = await parseRequest(req.clone(), {
       skipJFSVerification: true,
-      maxSkewSeconds: 60 * 60 * 24 * 365, // 1 year - permissive for emulator + tests
+      maxSkewSeconds: 60 * 60 * 24 * 365,
     });
     if (parsed.success && parsed.action.type === 'post') {
       inputs = parsed.action.inputs ?? {};
+      fid = parsed.action.user?.fid ?? parsed.action.fid;
     }
   } catch {
-    // ignore - try fallback raw parse
+    // try fallback raw parse
   }
-  // Fallback: try direct JSON body parse for inputs (in case JFS validation strict)
-  if (Object.keys(inputs).length === 0) {
+  if (Object.keys(inputs).length === 0 || fid === undefined) {
     try {
-      const body = (await req.clone().json()) as { payload?: string; inputs?: Record<string, unknown> };
+      const body = (await req.clone().json()) as {
+        payload?: string;
+        inputs?: Record<string, unknown>;
+        fid?: number;
+      };
       if (body.inputs && typeof body.inputs === 'object') {
         inputs = body.inputs;
-      } else if (typeof body.payload === 'string') {
-        // base64url-decode the payload
+      }
+      if (typeof body.fid === 'number') fid = body.fid;
+      if (typeof body.payload === 'string') {
         const padded = body.payload.replace(/-/g, '+').replace(/_/g, '/');
         const padding = padded.length % 4 === 0 ? '' : '='.repeat(4 - (padded.length % 4));
         const json = Buffer.from(padded + padding, 'base64').toString('utf8');
-        const decoded = JSON.parse(json) as { inputs?: Record<string, unknown> };
+        const decoded = JSON.parse(json) as {
+          inputs?: Record<string, unknown>;
+          fid?: number;
+          user?: { fid?: number };
+        };
         if (decoded.inputs && typeof decoded.inputs === 'object') {
           inputs = decoded.inputs;
+        }
+        if (fid === undefined) {
+          fid = decoded.user?.fid ?? decoded.fid;
         }
       }
     } catch {
@@ -196,16 +237,23 @@ export async function POST(
     const optionRaw = String(voteValue ?? '').trim();
     if (optionRaw) {
       const tallies = await recordVote(encoded, blockIdx, optionRaw);
-      return snapJsonResponse(buildResultsDoc(doc, blockIdx, tallies, optionRaw), origin, encoded, pageId);
+      return snapJsonResponse(
+        buildResultsDoc(doc, blockIdx, tallies, optionRaw),
+        origin,
+        encoded,
+        pageId,
+      );
     }
   }
 
-  // Other inputs (slider, switch, toggle) - acknowledge with thank-you Snap
   if (Object.keys(inputs).length > 0) {
     return snapJsonResponse(buildAckDoc(doc, inputs), origin, encoded, pageId);
   }
 
-  return snapJsonResponse(doc, origin, encoded, pageId);
+  // Bare submit (e.g. Unlock button on a gated block) - re-render with gates
+  // evaluated against the now-known FID.
+  const gateResults = await resolveGatesForPage(doc, pageId, fid);
+  return snapJsonResponse(doc, origin, encoded, pageId, gateResults);
 }
 
 function buildResultsDoc(

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -1,5 +1,7 @@
 // Block schema for the Zlank builder.
 
+import type { GateRule } from './gates';
+
 export type BlockType =
   | 'header'
   | 'text'
@@ -139,7 +141,7 @@ export interface SwitchBlock {
   defaultChecked: boolean;
 }
 
-export type Block =
+type AnyBlock =
   | HeaderBlock
   | TextBlock
   | LinkBlock
@@ -155,6 +157,11 @@ export type Block =
   | ProgressBlock
   | SliderBlock
   | SwitchBlock;
+
+// Optional `gate` lets a block require a token-balance check before render.
+// Evaluated server-side on POST; falsy on GET (no FID), so gated blocks
+// render as a locked stub until the user taps Unlock.
+export type Block = AnyBlock & { gate?: GateRule };
 
 export type ThemeAccent =
   | 'purple' | 'amber' | 'blue' | 'green' | 'red' | 'pink' | 'teal' | 'gray';

--- a/lib/gates.ts
+++ b/lib/gates.ts
@@ -1,0 +1,123 @@
+import { createPublicClient, http, erc20Abi, getAddress, type Address } from 'viem';
+import { base } from 'viem/chains';
+
+// Token-balance gate. Server-side only. POST handler resolves the user's
+// FID -> primary verified ETH address (Neynar) -> ERC-20 balance on Base.
+// Cached briefly in Redis to avoid hammering Neynar/RPC on every render.
+
+export interface GateRule {
+  type: 'token-balance';
+  /** ERC-20 contract address on Base. */
+  token: string;
+  /** Optional symbol shown in the upsell button label. */
+  symbol?: string;
+  /** Minimum balance, decimal string in human units (e.g. "1" or "0.5"). */
+  minBalance: string;
+  /** Token decimals. Defaults to 18. */
+  decimals?: number;
+  /** URL the upsell button opens (e.g. swap link). Optional. */
+  upsellUrl?: string;
+}
+
+const NEYNAR_API_KEY = process.env.NEYNAR_API_KEY ?? '';
+const RPC_URL = process.env.BASE_RPC_URL ?? 'https://mainnet.base.org';
+
+const publicClient = createPublicClient({ chain: base, transport: http(RPC_URL) });
+
+export function isGateRule(value: unknown): value is GateRule {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Partial<GateRule>;
+  return (
+    v.type === 'token-balance' &&
+    typeof v.token === 'string' &&
+    /^0x[a-fA-F0-9]{40}$/.test(v.token) &&
+    typeof v.minBalance === 'string' &&
+    v.minBalance.length > 0
+  );
+}
+
+interface NeynarUser {
+  fid: number;
+  verified_addresses?: { eth_addresses?: string[] };
+  custody_address?: string;
+}
+
+async function fetchPrimaryAddress(fid: number): Promise<Address | null> {
+  if (!NEYNAR_API_KEY) return null;
+  try {
+    const res = await fetch(
+      `https://api.neynar.com/v2/farcaster/user/bulk?fids=${fid}`,
+      {
+        headers: { 'x-api-key': NEYNAR_API_KEY, accept: 'application/json' },
+      },
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as { users?: NeynarUser[] };
+    const user = data.users?.[0];
+    if (!user) return null;
+    const verified = user.verified_addresses?.eth_addresses?.[0];
+    const addr = verified ?? user.custody_address ?? null;
+    if (!addr) return null;
+    return getAddress(addr);
+  } catch {
+    return null;
+  }
+}
+
+function parseHumanAmount(amount: string, decimals: number): bigint {
+  const [whole, frac = ''] = amount.split('.');
+  const fracPadded = (frac + '0'.repeat(decimals)).slice(0, decimals);
+  const cleanWhole = whole.replace(/^0+(?=\d)/, '') || '0';
+  const concat = (cleanWhole + fracPadded).replace(/^0+(?=\d)/, '');
+  return BigInt(concat || '0');
+}
+
+export interface GateContext {
+  /** FID of the viewer, when known (POST). undefined on GET. */
+  fid?: number;
+}
+
+export interface GateResult {
+  passed: boolean;
+  reason: 'no_fid' | 'no_address' | 'below_threshold' | 'rpc_error' | 'ok';
+  balance?: string;
+}
+
+export async function evaluateGate(
+  rule: GateRule,
+  ctx: GateContext,
+): Promise<GateResult> {
+  if (!ctx.fid) return { passed: false, reason: 'no_fid' };
+  const address = await fetchPrimaryAddress(ctx.fid);
+  if (!address) return { passed: false, reason: 'no_address' };
+  const decimals = rule.decimals ?? 18;
+  const minWei = parseHumanAmount(rule.minBalance, decimals);
+  try {
+    const balance = await publicClient.readContract({
+      address: getAddress(rule.token),
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [address],
+    });
+    if (balance >= minWei) {
+      return { passed: true, reason: 'ok', balance: balance.toString() };
+    }
+    return { passed: false, reason: 'below_threshold', balance: balance.toString() };
+  } catch {
+    return { passed: false, reason: 'rpc_error' };
+  }
+}
+
+/**
+ * Evaluate gates for a list of (index, rule) pairs in parallel.
+ * Returns a Map of blockIdx -> GateResult.
+ */
+export async function evaluateGates(
+  rules: Array<{ idx: number; rule: GateRule }>,
+  ctx: GateContext,
+): Promise<Map<number, GateResult>> {
+  const results = await Promise.all(
+    rules.map(async ({ idx, rule }) => [idx, await evaluateGate(rule, ctx)] as const),
+  );
+  return new Map(results);
+}

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -1,10 +1,58 @@
 import type { SnapDoc, Block } from './blocks';
+import type { GateResult } from './gates';
 
 interface Element {
   type: string;
   props?: Record<string, unknown>;
   children?: string[];
   on?: Record<string, unknown>;
+}
+
+/**
+ * Replace a gated block with a stub when the viewer fails the gate.
+ * - no_fid (GET / unauth POST): "Unlock" submit button (server re-evaluates on POST)
+ * - below_threshold / no_address: upsell button (open_url to swap, or generic message)
+ */
+function gateStubElements(
+  block: Block,
+  idx: number,
+  baseUrl: string,
+  gate: GateResult,
+): { ids: string[]; elements: Record<string, Element> } {
+  const id = `b${idx}`;
+  const elements: Record<string, Element> = {};
+  const rule = block.gate;
+
+  if (gate.reason === 'no_fid') {
+    elements[id] = {
+      type: 'button',
+      props: {
+        label: rule?.symbol ? `Unlock for ${rule.symbol} holders` : 'Unlock',
+        variant: 'secondary',
+        icon: 'check',
+      },
+      on: { press: { action: 'submit', params: { target: baseUrl } } },
+    };
+    return { ids: [id], elements };
+  }
+
+  // Failed (no address, below threshold, RPC error): show upsell.
+  const label = rule?.symbol
+    ? `Holders only - get ${rule.symbol}`
+    : 'Holders only';
+  if (rule?.upsellUrl) {
+    elements[id] = {
+      type: 'button',
+      props: { label, variant: 'secondary', icon: 'external-link' },
+      on: { press: { action: 'open_url', params: { target: rule.upsellUrl } } },
+    };
+  } else {
+    elements[id] = {
+      type: 'text',
+      props: { content: label, size: 'sm' },
+    };
+  }
+  return { ids: [id], elements };
 }
 
 function blockToElements(
@@ -259,18 +307,47 @@ function blockToElements(
   return { ids, elements };
 }
 
-export function docToSnap(doc: SnapDoc, baseUrl: string, pageId?: string) {
-  const targetPage = pageId || doc.pages[0]?.id;
+export interface DocToSnapOpts {
+  pageId?: string;
+  /** Per-block-index gate results from POST handler. */
+  gateResults?: Map<number, GateResult>;
+}
+
+export function docToSnap(
+  doc: SnapDoc,
+  baseUrl: string,
+  pageIdOrOpts?: string | DocToSnapOpts,
+) {
+  const opts: DocToSnapOpts =
+    typeof pageIdOrOpts === 'string'
+      ? { pageId: pageIdOrOpts }
+      : (pageIdOrOpts ?? {});
+  const targetPage = opts.pageId || doc.pages[0]?.id;
   const page = doc.pages.find((p) => p.id === targetPage);
 
   if (!page) {
-    return docToSnap(doc, baseUrl, doc.pages[0]?.id);
+    return docToSnap(doc, baseUrl, { ...opts, pageId: doc.pages[0]?.id });
   }
 
   const allElements: Record<string, Element> = {};
   const childIds: string[] = [];
 
   page.blocks.forEach((block, idx) => {
+    if (block.gate) {
+      const result = opts.gateResults?.get(idx);
+      const passed = result?.passed === true;
+      if (!passed) {
+        const stub = gateStubElements(
+          block,
+          idx,
+          baseUrl,
+          result ?? { passed: false, reason: 'no_fid' },
+        );
+        Object.assign(allElements, stub.elements);
+        childIds.push(...stub.ids);
+        return;
+      }
+    }
     const { ids, elements } = blockToElements(block, idx, baseUrl);
     Object.assign(allElements, elements);
     childIds.push(...ids);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "redis": "^5.12.1"
+        "redis": "^5.12.1",
+        "viem": "^2.48.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "redis": "^5.12.1"
+    "redis": "^5.12.1",
+    "viem": "^2.48.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
First of three builds from research doc 527. Any block can now carry a `gate` field that conditionally renders the block based on the viewer's on-chain ERC-20 balance on Base.

## How it works
- Block schema gets `gate?: { type: 'token-balance', token, symbol?, minBalance, decimals?, upsellUrl? }`
- POST handler extracts viewer FID from JFS payload, batches gate evaluation (Neynar FID -> primary verified ETH address -> viem `balanceOf` on Base)
- GET has no FID -> gated blocks render as "Unlock" submit buttons. Tap fires POST which re-renders with gates evaluated.
- Failed gate -> upsell button (`open_url` to `upsellUrl`) or text fallback.

## Test snap
Live: https://www.zlank.online/api/snap/zn_uYK
- Public blocks render normally
- 2 ZABAL-gated blocks render as "Unlock for ZABAL holders" buttons on GET
- On POST: real holders see the content, non-holders see upsell button to Uniswap swap

## To enable on prod
Add `NEYNAR_API_KEY` to Vercel env (`vercel env add NEYNAR_API_KEY production`). Without it, gates always fail (locked stubs stay locked - safe default).
Optionally `BASE_RPC_URL` if you want to swap the public Base RPC for a paid one.

## Out of scope (intentional)
Builder UI for gates. Gates ship as a server-side feature first; v1.5 will expose a per-block "Gate to..." dropdown in the visual builder.

## Test plan
- [ ] Add NEYNAR_API_KEY in Vercel
- [ ] Open https://www.zlank.online/api/snap/zn_uYK in snap-emulator with your FID
- [ ] If you hold >= 1 ZABAL, gated blocks render the real content
- [ ] If you don't, upsell button opens Uniswap swap