### PR TITLE
feat(blocks): feedback block - inline input + auto-tag composer

### DIFF
--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -246,6 +246,25 @@ export async function POST(
     }
   }
 
+  const feedbackEntry = Object.entries(inputs).find(([k]) => k.startsWith('feedback_'));
+  if (feedbackEntry) {
+    const [fbKey, fbValue] = feedbackEntry;
+    const blockIdx = Number(fbKey.replace('feedback_', ''));
+    const text = String(fbValue ?? '').trim();
+    if (text) {
+      const targetPage = doc.pages.find((p) => p.id === (pageId || doc.pages[0]?.id));
+      const block = targetPage?.blocks[blockIdx];
+      if (block?.type === 'feedback') {
+        return snapJsonResponse(
+          buildFeedbackComposeDoc(doc, block, text),
+          origin,
+          encoded,
+          pageId,
+        );
+      }
+    }
+  }
+
   if (Object.keys(inputs).length > 0) {
     return snapJsonResponse(buildAckDoc(doc, inputs), origin, encoded, pageId);
   }
@@ -275,6 +294,36 @@ function buildResultsDoc(
   return {
     ...doc,
     pages: [{ id: 'results', blocks: newBlocks }],
+    confetti: true,
+  };
+}
+
+function buildFeedbackComposeDoc(
+  doc: SnapDoc,
+  block: { mention: string; prefix?: string; channelKey?: string },
+  text: string,
+): SnapDoc {
+  const mention = block.mention.replace(/^@/, '');
+  const prefix = block.prefix ? `${block.prefix} ` : '';
+  const cast = `@${mention} ${prefix}${text}`.slice(0, 1024);
+  const newBlocks: Block[] = [
+    {
+      type: 'header',
+      title: 'Ready to send',
+      subtitle: `Will tag @${mention}. Tap to open the composer.`,
+    },
+    { type: 'text', content: cast },
+    {
+      type: 'share',
+      label: 'Open composer',
+      text: cast,
+      icon: 'message-circle',
+      channelKey: block.channelKey,
+    },
+  ];
+  return {
+    ...doc,
+    pages: [{ id: 'feedback-confirm', blocks: newBlocks }],
     confetti: true,
   };
 }

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -31,6 +31,7 @@ const BLOCK_OPTIONS: { type: BlockType; label: string; icon: string }[] = [
   { type: 'progress', label: 'Progress', icon: '%' },
   { type: 'slider', label: 'Slider', icon: '~' },
   { type: 'switch', label: 'Switch', icon: 'O' },
+  { type: 'feedback', label: 'Feedback', icon: '@' },
   { type: 'divider', label: 'Divider', icon: '-' },
 ];
 
@@ -96,6 +97,14 @@ function newBlock(type: BlockType, availablePageIds: string[] = []): Block {
       return { type: 'slider', label: 'Rate it', min: 0, max: 10, defaultValue: 7 };
     case 'switch':
       return { type: 'switch', label: 'Subscribe to updates', defaultChecked: false };
+    case 'feedback':
+      return {
+        type: 'feedback',
+        label: 'Send feedback',
+        prompt: 'What should we add?',
+        mention: 'zaal',
+        prefix: 'feedback for zlank:',
+      };
   }
 }
 

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -17,7 +17,8 @@ export type BlockType =
   | 'navigate'
   | 'progress'
   | 'slider'
-  | 'switch';
+  | 'switch'
+  | 'feedback';
 
 // Subset of the 34 Snap icons - the most useful for blocks.
 export const ICONS = [
@@ -61,6 +62,8 @@ export interface ShareBlock {
   label: string;
   text: string;
   icon?: IconName;
+  /** Optional Farcaster channel key (without leading /). */
+  channelKey?: string;
 }
 
 export interface ImageBlock {
@@ -141,6 +144,20 @@ export interface SwitchBlock {
   defaultChecked: boolean;
 }
 
+// User types feedback inline. Submit returns a one-tap "Open composer"
+// button that pre-fills the cast: "@{mention} {prefix} {text}".
+export interface FeedbackBlock {
+  type: 'feedback';
+  label: string;
+  prompt: string;
+  /** FC handle without @, e.g. "zaal". */
+  mention: string;
+  /** Boilerplate prepended to user text. e.g. "feedback for zlank:". */
+  prefix?: string;
+  /** Channel key (without /) to optionally route the cast. */
+  channelKey?: string;
+}
+
 type AnyBlock =
   | HeaderBlock
   | TextBlock
@@ -156,7 +173,8 @@ type AnyBlock =
   | NavigateBlock
   | ProgressBlock
   | SliderBlock
-  | SwitchBlock;
+  | SwitchBlock
+  | FeedbackBlock;
 
 // Optional `gate` lets a block require a token-balance check before render.
 // Evaluated server-side on POST; falsy on GET (no FID), so gated blocks
@@ -252,6 +270,7 @@ export function clampBlock(block: Block): Block {
         label: block.label.slice(0, LABEL_MAX),
         text: block.text.slice(0, SHARE_TEXT_MAX),
         icon: clampIcon(block.icon),
+        channelKey: block.channelKey?.replace(/^\//, '').slice(0, NAME_MAX),
       };
     case 'image':
       return {
@@ -327,6 +346,15 @@ export function clampBlock(block: Block): Block {
         ...block,
         label: block.label.slice(0, LABEL_MAX),
         defaultChecked: Boolean(block.defaultChecked),
+      };
+    case 'feedback':
+      return {
+        ...block,
+        label: block.label.slice(0, LABEL_MAX),
+        prompt: block.prompt.slice(0, QUESTION_MAX),
+        mention: String(block.mention || 'zaal').replace(/^@/, '').slice(0, NAME_MAX),
+        prefix: block.prefix?.slice(0, LABEL_MAX),
+        channelKey: block.channelKey?.replace(/^\//, '').slice(0, NAME_MAX),
       };
   }
 }

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -110,15 +110,15 @@ function blockToElements(
     case 'share': {
       const props: Record<string, unknown> = { label: block.label };
       props.icon = block.icon ?? 'share';
+      const composeParams: Record<string, unknown> = {
+        text: block.text,
+        embeds: [baseUrl],
+      };
+      if (block.channelKey) composeParams.channelKey = block.channelKey;
       elements[id] = {
         type: 'button',
         props,
-        on: {
-          press: {
-            action: 'compose_cast',
-            params: { text: block.text, embeds: [baseUrl] },
-          },
-        },
+        on: { press: { action: 'compose_cast', params: composeParams } },
       };
       ids.push(id);
       break;
@@ -300,6 +300,36 @@ function blockToElements(
         },
       };
       ids.push(switchId, btnId);
+      break;
+    }
+    case 'feedback': {
+      // Inline input + submit. POST handler reads `feedback_${idx}` and
+      // returns a follow-up Snap with a one-tap compose_cast button.
+      const promptId = `${id}_prompt`;
+      const inputId = `${id}_input`;
+      const btnId = `${id}_btn`;
+      elements[promptId] = {
+        type: 'text',
+        props: { content: block.prompt, size: 'md', weight: 'bold' },
+      };
+      elements[inputId] = {
+        type: 'input',
+        props: {
+          name: `feedback_${idx}`,
+          type: 'text',
+          label: block.label,
+          placeholder: 'Type your suggestion...',
+          maxLength: 240,
+        },
+      };
+      elements[btnId] = {
+        type: 'button',
+        props: { label: block.label || 'Send feedback', variant: 'primary', icon: 'message-circle' },
+        on: {
+          press: { action: 'submit', params: { target: baseUrl } },
+        },
+      };
+      ids.push(promptId, inputId, btnId);
       break;
     }
   }


### PR DESCRIPTION
## Summary
New 15th block type. User types feedback in the Snap, taps Submit, gets a follow-up Snap with a one-tap "Open composer" button pre-filled with `@{mention} {prefix} {text}`.

Uses `compose_cast` action (already in @farcaster/snap catalog) - no signer key, no auth, no API. FC client opens its native composer with the text pre-loaded; user reviews + sends.

Also extended ShareBlock with optional `channelKey` for channel routing on cast composes.

## Live test
https://www.zlank.online/api/snap/kZUJVv

Submit "add a video block + a token-launch shortcut" -> follow-up Snap renders:
- Header: "Ready to send"
- Text preview: `@zaal feedback for zlank: add a video block + a token-launch shortcut`
- Button "Open composer" with compose_cast action carrying the cast text

## Schema
```ts
interface FeedbackBlock {
  type: 'feedback';
  label: string;
  prompt: string;
  mention: string;       // FC handle without @, e.g. "zaal"
  prefix?: string;       // boilerplate prepended, e.g. "feedback for zlank:"
  channelKey?: string;   // optional FC channel routing
}
```

## Test plan
- [ ] Open the test snap in snap-emulator with any FID
- [ ] Type a suggestion + Submit
- [ ] See follow-up Snap with composer button
- [ ] Tap composer button - FC native composer opens with the cast pre-filled