### PR TITLE
feat(blocks): chatbot block + Redis log + Minimax/Anthropic LLM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,12 @@ NEYNAR_API_KEY=
 # Optional: Base mainnet RPC URL for ERC-20 balanceOf reads on token gates.
 # Defaults to the public Base RPC when unset.
 BASE_RPC_URL=
+
+# Optional: LLM keys for the chatbot block. If both unset, the block logs
+# user input but returns a static ack. Minimax preferred (cheaper); Anthropic
+# Haiku used as fallback.
+MINIMAX_API_KEY=
+MINIMAX_API_URL=
+MINIMAX_MODEL=
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=

--- a/app/api/chat-log/[id]/route.ts
+++ b/app/api/chat-log/[id]/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getChatLog } from '@/lib/kv';
+
+export const runtime = 'nodejs';
+
+// GET /api/chat-log/{snapId}?limit=50
+// Public read of what people have shared via chatbot blocks on a snap.
+// Lets a creator see "what are people building" without an admin login.
+// Capped at 100 entries per request.
+
+export async function GET(
+  req: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  const limitParam = new URL(req.url).searchParams.get('limit');
+  const limit = Math.min(Math.max(Number(limitParam) || 50, 1), 100);
+  const entries = await getChatLog(id, limit);
+  return NextResponse.json(
+    { snapId: id, count: entries.length, entries },
+    {
+      headers: {
+        'cache-control': 'no-store',
+        'access-control-allow-origin': '*',
+      },
+    },
+  );
+}

--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { parseRequest } from '@farcaster/snap/server';
 import { resolveSnap } from '@/lib/resolve-snap';
 import { docToSnap } from '@/lib/snap-spec';
-import { recordVote } from '@/lib/kv';
+import { recordVote, appendChatLog } from '@/lib/kv';
 import { evaluateGates, isGateRule, type GateResult } from '@/lib/gates';
+import { chat as llmChat } from '@/lib/llm';
 import type { SnapDoc, Block, ChartBar } from '@/lib/blocks';
 
 export const runtime = 'nodejs';
@@ -246,6 +247,33 @@ export async function POST(
     }
   }
 
+  const chatEntry = Object.entries(inputs).find(([k]) => k.startsWith('chat_'));
+  if (chatEntry) {
+    const [chatKey, chatValue] = chatEntry;
+    const blockIdx = Number(chatKey.replace('chat_', ''));
+    const text = String(chatValue ?? '').trim();
+    if (text) {
+      const targetPage = doc.pages.find((p) => p.id === (pageId || doc.pages[0]?.id));
+      const block = targetPage?.blocks[blockIdx];
+      if (block?.type === 'chatbot') {
+        const reply = await llmChat(
+          [
+            { role: 'system', content: block.systemPrompt },
+            { role: 'user', content: text },
+          ],
+          { maxTokens: 180 },
+        );
+        await appendChatLog(encoded, { ts: Date.now(), fid, text, reply });
+        return snapJsonResponse(
+          buildChatReplyDoc(doc, block, text, reply, blockIdx),
+          origin,
+          encoded,
+          pageId,
+        );
+      }
+    }
+  }
+
   const feedbackEntry = Object.entries(inputs).find(([k]) => k.startsWith('feedback_'));
   if (feedbackEntry) {
     const [fbKey, fbValue] = feedbackEntry;
@@ -295,6 +323,37 @@ function buildResultsDoc(
     ...doc,
     pages: [{ id: 'results', blocks: newBlocks }],
     confetti: true,
+  };
+}
+
+function buildChatReplyDoc(
+  doc: SnapDoc,
+  block: { title: string; prompt: string; systemPrompt: string; label: string; placeholder?: string },
+  userText: string,
+  reply: string | null,
+  _blockIdx: number,
+): SnapDoc {
+  const replyText =
+    reply ??
+    'Logged. (No LLM key configured - ack only. Set MINIMAX_API_KEY or ANTHROPIC_API_KEY to enable replies.)';
+  const newBlocks: Block[] = [
+    { type: 'header', title: block.title, subtitle: 'Got it' },
+    { type: 'text', content: `You: ${userText.slice(0, 240)}` },
+    { type: 'divider' },
+    { type: 'text', content: replyText.slice(0, 320) },
+    { type: 'divider' },
+    {
+      type: 'chatbot',
+      title: block.title,
+      prompt: block.prompt,
+      systemPrompt: block.systemPrompt,
+      label: block.label,
+      placeholder: block.placeholder,
+    },
+  ];
+  return {
+    ...doc,
+    pages: [{ id: 'chat-reply', blocks: newBlocks }],
   };
 }
 

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -32,6 +32,7 @@ const BLOCK_OPTIONS: { type: BlockType; label: string; icon: string }[] = [
   { type: 'slider', label: 'Slider', icon: '~' },
   { type: 'switch', label: 'Switch', icon: 'O' },
   { type: 'feedback', label: 'Feedback', icon: '@' },
+  { type: 'chatbot', label: 'Chatbot', icon: 'C' },
   { type: 'divider', label: 'Divider', icon: '-' },
 ];
 
@@ -104,6 +105,16 @@ function newBlock(type: BlockType, availablePageIds: string[] = []): Block {
         prompt: 'What should we add?',
         mention: 'zaal',
         prefix: 'feedback for zlank:',
+      };
+    case 'chatbot':
+      return {
+        type: 'chatbot',
+        title: 'What are you building?',
+        prompt: 'Share your idea. Reply comes back inline.',
+        systemPrompt:
+          'You are a friendly builder coach. Reply briefly (max 2 sentences) and ask one curious follow-up about what they are making.',
+        label: 'Send',
+        placeholder: 'Type here...',
       };
   }
 }

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -18,7 +18,8 @@ export type BlockType =
   | 'progress'
   | 'slider'
   | 'switch'
-  | 'feedback';
+  | 'feedback'
+  | 'chatbot';
 
 // Subset of the 34 Snap icons - the most useful for blocks.
 export const ICONS = [
@@ -144,6 +145,24 @@ export interface SwitchBlock {
   defaultChecked: boolean;
 }
 
+// User chats with an LLM inline. Submit logs the message + LLM reply to
+// Redis (chatlog:{snapId}) and returns a Snap with the reply + same chatbot
+// block to keep the loop going. Stateless per-turn (Snap protocol has no
+// per-user state surface yet).
+export interface ChatbotBlock {
+  type: 'chatbot';
+  /** Title shown above the chat input. */
+  title: string;
+  /** Subtitle / instructions. */
+  prompt: string;
+  /** System prompt that frames the LLM. */
+  systemPrompt: string;
+  /** Submit button label. */
+  label: string;
+  /** Placeholder for the input. */
+  placeholder?: string;
+}
+
 // User types feedback inline. Submit returns a one-tap "Open composer"
 // button that pre-fills the cast: "@{mention} {prefix} {text}".
 export interface FeedbackBlock {
@@ -174,7 +193,8 @@ type AnyBlock =
   | ProgressBlock
   | SliderBlock
   | SwitchBlock
-  | FeedbackBlock;
+  | FeedbackBlock
+  | ChatbotBlock;
 
 // Optional `gate` lets a block require a token-balance check before render.
 // Evaluated server-side on POST; falsy on GET (no FID), so gated blocks
@@ -355,6 +375,15 @@ export function clampBlock(block: Block): Block {
         mention: String(block.mention || 'zaal').replace(/^@/, '').slice(0, NAME_MAX),
         prefix: block.prefix?.slice(0, LABEL_MAX),
         channelKey: block.channelKey?.replace(/^\//, '').slice(0, NAME_MAX),
+      };
+    case 'chatbot':
+      return {
+        ...block,
+        title: block.title.slice(0, TITLE_MAX),
+        prompt: block.prompt.slice(0, QUESTION_MAX),
+        systemPrompt: block.systemPrompt.slice(0, 2000),
+        label: block.label.slice(0, LABEL_MAX),
+        placeholder: block.placeholder?.slice(0, 60),
       };
   }
 }

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -149,3 +149,47 @@ export async function getVotes(
   for (const [k, v] of Object.entries(tallies)) out[k] = Number(v);
   return out;
 }
+
+const CHATLOG_PREFIX = 'chatlog:';
+const CHATLOG_MAX = 500;
+
+export interface ChatLogEntry {
+  ts: number;
+  fid?: number;
+  text: string;
+  reply?: string | null;
+}
+
+export async function appendChatLog(
+  snapId: string,
+  entry: ChatLogEntry,
+): Promise<void> {
+  const c = await getClient();
+  if (!c) return;
+  const key = CHATLOG_PREFIX + snapId;
+  await c.lPush(key, JSON.stringify(entry));
+  await c.lTrim(key, 0, CHATLOG_MAX - 1);
+  await c.expire(key, 60 * 60 * 24 * 90);
+}
+
+export async function getChatLog(
+  snapId: string,
+  limit = 50,
+): Promise<ChatLogEntry[]> {
+  const c = await getClient();
+  if (!c) return [];
+  const raw = await c.lRange(
+    CHATLOG_PREFIX + snapId,
+    0,
+    Math.min(limit, CHATLOG_MAX) - 1,
+  );
+  const out: ChatLogEntry[] = [];
+  for (const r of raw) {
+    try {
+      out.push(JSON.parse(r) as ChatLogEntry);
+    } catch {
+      // skip malformed
+    }
+  }
+  return out;
+}

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -1,0 +1,85 @@
+// Thin chat-completion wrapper. Minimax primary, Anthropic Haiku fallback.
+// Both are optional - if no key set, caller falls back to a canned reply.
+
+interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+const MINIMAX_KEY = process.env.MINIMAX_API_KEY;
+const MINIMAX_URL =
+  process.env.MINIMAX_API_URL || 'https://api.minimax.io/v1/chat/completions';
+const MINIMAX_MODEL = process.env.MINIMAX_MODEL || 'MiniMax-M2.7';
+
+const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY;
+const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || 'claude-haiku-4-5-20251001';
+
+export async function chat(
+  messages: ChatMessage[],
+  opts: { maxTokens?: number; timeoutMs?: number } = {},
+): Promise<string | null> {
+  const maxTokens = opts.maxTokens ?? 200;
+  const timeoutMs = opts.timeoutMs ?? 8000;
+
+  if (MINIMAX_KEY) {
+    try {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+      const res = await fetch(MINIMAX_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${MINIMAX_KEY}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ model: MINIMAX_MODEL, messages, max_tokens: maxTokens }),
+        signal: ctrl.signal,
+      });
+      clearTimeout(timer);
+      if (res.ok) {
+        const data = (await res.json()) as {
+          choices?: Array<{ message?: { content?: string } }>;
+        };
+        const text = data.choices?.[0]?.message?.content?.trim();
+        if (text) return text;
+      }
+    } catch {
+      // fall through to Anthropic
+    }
+  }
+
+  if (ANTHROPIC_KEY) {
+    try {
+      const ctrl = new AbortController();
+      const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+      const sys = messages.find((m) => m.role === 'system')?.content;
+      const conv = messages.filter((m) => m.role !== 'system');
+      const res = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': ANTHROPIC_KEY,
+          'anthropic-version': '2023-06-01',
+        },
+        body: JSON.stringify({
+          model: ANTHROPIC_MODEL,
+          max_tokens: maxTokens,
+          system: sys,
+          messages: conv,
+        }),
+        signal: ctrl.signal,
+      });
+      clearTimeout(timer);
+      if (res.ok) {
+        const data = (await res.json()) as {
+          content?: Array<{ type: string; text?: string }>;
+        };
+        const text = data.content?.find((b) => b.type === 'text')?.text?.trim();
+        if (text) return text;
+      }
+    } catch {
+      // give up
+    }
+  }
+
+  return null;
+}

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -332,6 +332,37 @@ function blockToElements(
       ids.push(promptId, inputId, btnId);
       break;
     }
+    case 'chatbot': {
+      const titleId = `${id}_title`;
+      const promptId = `${id}_prompt`;
+      const inputId = `${id}_input`;
+      const btnId = `${id}_btn`;
+      elements[titleId] = {
+        type: 'item',
+        props: { title: block.title, description: block.prompt },
+      };
+      elements[promptId] = {
+        type: 'text',
+        props: { content: 'Logged for the builder. Reply comes back inline.', size: 'sm' },
+      };
+      elements[inputId] = {
+        type: 'input',
+        props: {
+          name: `chat_${idx}`,
+          type: 'text',
+          label: block.label,
+          placeholder: block.placeholder ?? 'What are you trying to build?',
+          maxLength: 240,
+        },
+      };
+      elements[btnId] = {
+        type: 'button',
+        props: { label: block.label || 'Send', variant: 'primary', icon: 'message-circle' },
+        on: { press: { action: 'submit', params: { target: baseUrl } } },
+      };
+      ids.push(titleId, promptId, inputId, btnId);
+      break;
+    }
   }
 
   return { ids, elements };


### PR DESCRIPTION
## Summary
16th block type. Lets people share what they're building inside a Snap. Every entry logs to Redis. Optional LLM reply comes back inline.

## Flow
1. Snap renders chatbot block: title + prompt + input + Send button
2. User types + Submit -> POST `chat_${idx}`
3. Server: `appendChatLog(snapId, {ts, fid, text, reply})` to Redis (LPUSH, capped 500, 90-day TTL)
4. Server calls `chat()` from `lib/llm.ts` (Minimax primary, Anthropic Haiku fallback, both optional)
5. Returns Snap: header + "You: {text}" + LLM reply (or canned ack if no key) + fresh chatbot block

## Live tests
- Chatbot snap: https://www.zlank.online/api/snap/v8-myn
- All-16-blocks demo: https://www.zlank.online/api/snap/nBi8N6
- Read the log: https://www.zlank.online/api/chat-log/v8-myn

## To enable LLM replies
Set on Vercel:
```
vercel env add MINIMAX_API_KEY production
# or
vercel env add ANTHROPIC_API_KEY production
```
Without either, the block still logs every entry - just returns a static ack instead of an LLM reply. Safe default.

## Schema
```ts
interface ChatbotBlock {
  type: 'chatbot';
  title: string;
  prompt: string;
  systemPrompt: string;   // frames the LLM
  label: string;
  placeholder?: string;
}
```

## API
`GET /api/chat-log/{snapId}?limit=50` returns:
```json
{ "snapId": "...", "count": N, "entries": [{ "ts", "fid", "text", "reply" }] }
```
Capped at 100 per request.

## Stack note
Built on existing `lib/kv.ts` patterns (LPUSH+LTRIM+EXPIRE, parallel to vote tallies). New `lib/llm.ts` is a tiny wrapper - 80 lines, no SDKs.

## Test plan
- [ ] Open the chatbot snap in snap-emulator with any FID
- [ ] Send "a remix marketplace for AI prompts"
- [ ] See follow-up Snap with ack + fresh input
- [ ] GET /api/chat-log/v8-myn -> see your message in `entries`
- [ ] Add MINIMAX_API_KEY (or ANTHROPIC_API_KEY) to Vercel + redeploy
- [ ] Re-test - real LLM reply renders inline