### PR TITLE
feat(builder): edit fields for chatbot+feedback + 2 templates (closes #14, #20)

### DIFF
--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -793,6 +793,80 @@ function BlockEditor({
           </select>
         </>
       )}
+      {block.type === 'feedback' && (
+        <>
+          <input
+            value={block.label}
+            onChange={(e) => onChange({ label: e.target.value } as Partial<Block>)}
+            placeholder="Button label (e.g. Send feedback)"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <input
+            value={block.prompt}
+            onChange={(e) => onChange({ prompt: e.target.value } as Partial<Block>)}
+            placeholder="Prompt (e.g. What should we add?)"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <div className="flex gap-2">
+            <span className="text-sm text-[#8aa0bd] self-center">@</span>
+            <input
+              value={block.mention}
+              onChange={(e) => onChange({ mention: e.target.value.replace(/^@/, '') } as Partial<Block>)}
+              placeholder="zaal"
+              className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            />
+          </div>
+          <input
+            value={block.prefix ?? ''}
+            onChange={(e) => onChange({ prefix: e.target.value } as Partial<Block>)}
+            placeholder="Prefix (e.g. feedback for zlank:)"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <input
+            value={block.channelKey ?? ''}
+            onChange={(e) => onChange({ channelKey: e.target.value.replace(/^\//, '') } as Partial<Block>)}
+            placeholder="Channel key (optional, no leading /)"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+        </>
+      )}
+      {block.type === 'chatbot' && (
+        <>
+          <input
+            value={block.title}
+            onChange={(e) => onChange({ title: e.target.value } as Partial<Block>)}
+            placeholder="Title (e.g. What are you building?)"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <input
+            value={block.prompt}
+            onChange={(e) => onChange({ prompt: e.target.value } as Partial<Block>)}
+            placeholder="Subtitle / prompt"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <textarea
+            value={block.systemPrompt}
+            onChange={(e) => onChange({ systemPrompt: e.target.value } as Partial<Block>)}
+            placeholder="System prompt - frames the LLM"
+            rows={3}
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <div className="flex gap-2">
+            <input
+              value={block.label}
+              onChange={(e) => onChange({ label: e.target.value } as Partial<Block>)}
+              placeholder="Button label"
+              className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            />
+            <input
+              value={block.placeholder ?? ''}
+              onChange={(e) => onChange({ placeholder: e.target.value } as Partial<Block>)}
+              placeholder="Input placeholder"
+              className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            />
+          </div>
+        </>
+      )}
       {block.type === 'divider' && <p className="text-xs text-[#8aa0bd]">Visual separator. No fields.</p>}
     </div>
   );

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -320,6 +320,80 @@ export const TEMPLATES: TemplateMeta[] = [
       ],
     },
   },
+  {
+    id: 'idea-box',
+    name: 'Idea Box',
+    description: 'Chatbot collects what people are building. Replies inline. Logs every entry.',
+    doc: {
+      version: 1,
+      title: 'What are you building?',
+      theme: 'purple',
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'Tell me what you are building',
+              subtitle: 'Reply comes back inline. Logged for the creator.',
+              badgeText: 'IDEAS',
+              badgeColor: 'purple',
+            },
+            {
+              type: 'chatbot',
+              title: 'Builder chat',
+              prompt: 'What are you working on right now?',
+              systemPrompt:
+                'You are a friendly product coach. Reply briefly (max 2 sentences) and ask one curious follow-up about what they are making. Be concrete.',
+              label: 'Send',
+              placeholder: 'Type your idea...',
+            },
+            { type: 'divider' },
+            {
+              type: 'text',
+              content: 'Read the log: zlank.online/api/chat-log/{snap-id}',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    id: 'bug-report',
+    name: 'Bug Report',
+    description: 'Feedback block tagging the creator with a structured prefix.',
+    doc: {
+      version: 1,
+      title: 'Bug report',
+      theme: 'red',
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'Found a bug?',
+              subtitle: 'Tell us what broke. One tap to send.',
+              badgeText: 'BUGS',
+              badgeColor: 'red',
+            },
+            {
+              type: 'feedback',
+              label: 'Send bug report',
+              prompt: 'Describe the bug + how to reproduce it',
+              mention: 'zaal',
+              prefix: 'bug for zlank:',
+            },
+            { type: 'divider' },
+            {
+              type: 'text',
+              content: 'Tagged @zaal. Composer opens pre-filled - review and send.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];
 
 export function getTemplateById(id: string): TemplateMeta | undefined {


### PR DESCRIPTION
## Summary
Two small wins from the issue queue:

**#14 fix**: BlockEditor now has inline edit fields for FeedbackBlock + ChatbotBlock. Previously you could add them from the picker but had no UI to configure them - had to hand-edit the saved doc.

**#20 ship**: 2 new templates in lib/templates.ts (now 10 total):
- **Idea Box** - chatbot w/ system coach prompt
- **Bug Report** - feedback block tagging @zaal w/ "bug for zlank:" prefix

## Test plan
- [ ] Open /builder, add a chatbot block, see all 5 fields (title, prompt, systemPrompt, label, placeholder) editable inline
- [ ] Add a feedback block, see all 5 fields (label, prompt, mention, prefix, channelKey) editable
- [ ] Open /templates, see 10 cards including Idea Box + Bug Report
- [ ] Click Idea Box -> deploys w/ pre-configured chatbot
- [ ] Click Bug Report -> deploys w/ feedback block tagging @zaal

Stacks under PR #11 (feedback) and PR #12 (chatbot). Merge order: #11 -> #12 -> this.