### PR TITLE
feat(validate): preflight Snap validation on save (closes #17)

### DIFF
--- a/app/api/snaps/route.ts
+++ b/app/api/snaps/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { isKvAvailable, saveSnap } from '@/lib/kv';
 import { encodeSnap } from '@/lib/encode';
+import { validateDoc } from '@/lib/validate-snap';
 import type { SnapDoc } from '@/lib/blocks';
 
 export const runtime = 'nodejs';
@@ -28,6 +29,22 @@ export async function POST(req: NextRequest) {
 
   if (!body || !isSnapDoc(body.doc)) {
     return NextResponse.json({ error: 'doc field missing or invalid' }, { status: 400 });
+  }
+
+  // Preflight: validate the rendered Snap UI for every page against the
+  // @farcaster/snap envelope schema + json-render catalog. If the doc would
+  // produce an invalid Snap (bad icon name, button label too long, etc.),
+  // reject before storing so the user fixes it now instead of after a cast.
+  const validation = validateDoc(body.doc);
+  if (!validation.ok) {
+    return NextResponse.json(
+      {
+        error: 'Snap validation failed',
+        issues: validation.errors,
+        pages: validation.pages,
+      },
+      { status: 400 },
+    );
   }
 
   if (!isKvAvailable()) {

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -253,7 +253,16 @@ export default function Builder() {
         body: JSON.stringify({ doc }),
       });
       if (!res.ok) {
-        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        const data = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          issues?: string[];
+        };
+        // Validation errors (400 w/ issues): surface them, do NOT silently
+        // fall back to URL-encode - that would hide an invalid Snap.
+        if (res.status === 400 && Array.isArray(data.issues) && data.issues.length > 0) {
+          setDeployErr(`Snap won't render. Fix:\n- ${data.issues.join('\n- ')}`);
+          return;
+        }
         throw new Error(data.error ?? `HTTP ${res.status}`);
       }
       const data = (await res.json()) as { id: string; short: boolean };
@@ -270,7 +279,7 @@ export default function Builder() {
         updatedAt: Date.now(),
       });
     } catch (err: unknown) {
-      // Fall back to URL-encode locally if API call fails
+      // Network / server error - fall back to URL-encode locally
       try {
         const encoded = encodeSnap(doc);
         setDeployed(encoded);

--- a/app/chat-log/[id]/page.tsx
+++ b/app/chat-log/[id]/page.tsx
@@ -1,0 +1,139 @@
+import Link from 'next/link';
+import { getChatLog, type ChatLogEntry } from '@/lib/kv';
+import { resolveSnap } from '@/lib/resolve-snap';
+
+export const runtime = 'nodejs';
+export const revalidate = 0;
+
+interface Props {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ limit?: string }>;
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  const date = d.toISOString().slice(0, 10);
+  const time = d.toISOString().slice(11, 16);
+  return `${date} ${time}`;
+}
+
+function relative(ts: number): string {
+  const diff = Date.now() - ts;
+  const m = Math.floor(diff / 60000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+export default async function ChatLogPage({ params, searchParams }: Props) {
+  const { id } = await params;
+  const sp = await searchParams;
+  const limit = Math.min(Math.max(Number(sp.limit) || 100, 1), 500);
+  const [entries, doc] = await Promise.all([
+    getChatLog(id, limit),
+    resolveSnap(id),
+  ]);
+  const title = doc?.title ?? id;
+
+  return (
+    <main className="min-h-screen bg-[#0a1628] text-[#e8eef7] px-4 py-8">
+      <div className="max-w-3xl mx-auto">
+        <div className="mb-6">
+          <Link href="/" className="text-[#8aa0bd] hover:text-[#f5a623] text-sm">
+            &larr; Zlank
+          </Link>
+          <h1 className="text-2xl font-bold text-[#f5a623] mt-2">Chat log</h1>
+          <p className="text-sm text-[#8aa0bd] mt-1">
+            {title} <span className="text-[#1f3252]">|</span> snap{' '}
+            <code className="text-[#f5a623]">{id}</code>
+          </p>
+          <p className="text-xs text-[#5e7290] mt-2">
+            {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
+            {entries.length === limit && ` (showing latest ${limit})`}
+            {' | '}
+            <Link
+              href={`/api/chat-log/${id}?limit=${limit}`}
+              className="hover:text-[#f5a623] underline"
+            >
+              JSON
+            </Link>
+            {' | '}
+            <Link
+              href={`/api/snap/${id}`}
+              className="hover:text-[#f5a623] underline"
+            >
+              Snap
+            </Link>
+          </p>
+        </div>
+
+        {entries.length === 0 ? (
+          <EmptyState id={id} />
+        ) : (
+          <ul className="space-y-3">
+            {entries.map((e, i) => (
+              <ChatRow key={i} entry={e} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}
+
+function ChatRow({ entry }: { entry: ChatLogEntry }) {
+  const fidLink = entry.fid
+    ? `https://farcaster.xyz/~/profiles/${entry.fid}`
+    : null;
+  return (
+    <li className="bg-[#122440] border border-[#1f3252] rounded-lg p-4">
+      <div className="flex items-center justify-between gap-3 mb-2 text-xs text-[#8aa0bd]">
+        <div>
+          {fidLink ? (
+            <a
+              href={fidLink}
+              target="_blank"
+              rel="noreferrer"
+              className="text-[#f5a623] hover:underline"
+            >
+              fid {entry.fid}
+            </a>
+          ) : (
+            <span>anonymous</span>
+          )}
+          <span className="ml-2">{relative(entry.ts)}</span>
+        </div>
+        <time className="text-[#5e7290]" title={formatTime(entry.ts)}>
+          {formatTime(entry.ts)}
+        </time>
+      </div>
+      <p className="text-sm text-[#e8eef7] whitespace-pre-wrap">{entry.text}</p>
+      {entry.reply && (
+        <div className="mt-3 pt-3 border-t border-[#1f3252]">
+          <p className="text-xs text-[#8aa0bd] mb-1">reply</p>
+          <p className="text-sm text-[#c9d4e3] whitespace-pre-wrap">
+            {entry.reply}
+          </p>
+        </div>
+      )}
+    </li>
+  );
+}
+
+function EmptyState({ id }: { id: string }) {
+  return (
+    <div className="bg-[#122440] border border-[#1f3252] rounded-lg p-8 text-center">
+      <p className="text-[#e8eef7] mb-2">No entries yet.</p>
+      <p className="text-sm text-[#8aa0bd]">
+        Cast{' '}
+        <code className="text-[#f5a623]">
+          https://zlank.online/api/snap/{id}
+        </code>{' '}
+        on Farcaster. Each chatbot submission lands here.
+      </p>
+    </div>
+  );
+}

--- a/lib/validate-snap.ts
+++ b/lib/validate-snap.ts
@@ -1,7 +1,83 @@
 import { validateSnapResponse, snapResponseSchema } from '@farcaster/snap';
 import { snapJsonRenderCatalog } from '@farcaster/snap/ui';
 import { docToSnap } from './snap-spec';
-import type { SnapDoc } from './blocks';
+import type { SnapDoc, Block } from './blocks';
+
+// Source-doc lint - catches user input mistakes that snap-spec would silently
+// paper over (e.g. empty text content gets padded with a space at render).
+function lintBlock(block: Block, idx: number): string[] {
+  const issues: string[] = [];
+  const here = `block ${idx} (${block.type})`;
+  switch (block.type) {
+    case 'text':
+      if (!block.content?.trim()) issues.push(`${here}: text content is empty`);
+      break;
+    case 'header':
+      if (!block.title?.trim()) issues.push(`${here}: header title is empty`);
+      break;
+    case 'link':
+      if (!block.label?.trim()) issues.push(`${here}: link label is empty`);
+      if (!/^https?:\/\//.test(block.url)) issues.push(`${here}: link url must start with https://`);
+      break;
+    case 'share':
+      if (!block.label?.trim()) issues.push(`${here}: share label is empty`);
+      if (!block.text?.trim()) issues.push(`${here}: share cast text is empty`);
+      break;
+    case 'image':
+      if (!block.url?.trim()) issues.push(`${here}: image url is empty`);
+      break;
+    case 'music':
+      if (!block.url?.trim()) issues.push(`${here}: music url is empty`);
+      if (!/^https?:\/\//.test(block.url)) issues.push(`${here}: music url must start with https://`);
+      break;
+    case 'artist':
+      if (!Number.isFinite(block.fid) || block.fid <= 0) {
+        issues.push(`${here}: artist fid must be a positive number`);
+      }
+      if (!block.displayName?.trim()) issues.push(`${here}: artist displayName is empty`);
+      break;
+    case 'poll':
+      if (!block.question?.trim()) issues.push(`${here}: poll question is empty`);
+      if (!Array.isArray(block.options) || block.options.length < 2) {
+        issues.push(`${here}: poll needs at least 2 options`);
+      }
+      break;
+    case 'toggle':
+      if (!Array.isArray(block.options) || block.options.length < 2) {
+        issues.push(`${here}: toggle needs at least 2 options`);
+      }
+      break;
+    case 'feedback':
+      if (!block.mention?.trim()) issues.push(`${here}: feedback mention is empty`);
+      if (!block.prompt?.trim()) issues.push(`${here}: feedback prompt is empty`);
+      break;
+    case 'chatbot':
+      if (!block.title?.trim()) issues.push(`${here}: chatbot title is empty`);
+      if (!block.systemPrompt?.trim()) {
+        issues.push(`${here}: chatbot systemPrompt is empty`);
+      }
+      break;
+    case 'navigate':
+      if (!block.pageId?.trim()) issues.push(`${here}: navigate pageId is empty`);
+      break;
+    case 'progress':
+      if (!Number.isFinite(block.max) || block.max <= 0) {
+        issues.push(`${here}: progress max must be > 0`);
+      }
+      break;
+    case 'slider':
+      if (block.min > block.max) {
+        issues.push(`${here}: slider min (${block.min}) must be <= max (${block.max})`);
+      }
+      break;
+    case 'chart':
+      if (!Array.isArray(block.bars) || block.bars.length === 0) {
+        issues.push(`${here}: chart needs at least 1 bar`);
+      }
+      break;
+  }
+  return issues;
+}
 
 export interface ValidatePageResult {
   pageId: string;
@@ -32,6 +108,13 @@ export function validateDoc(doc: SnapDoc, baseUrl = 'https://zlank.online/api/sn
 
   for (const page of doc.pages) {
     const issues: string[] = [];
+
+    // Source-doc lint first (catches user input mistakes regardless of how
+    // snap-spec.ts handles them at render time).
+    page.blocks.forEach((block, idx) => {
+      issues.push(...lintBlock(block, idx));
+    });
+
     let snap: unknown;
     try {
       snap = docToSnap(doc, baseUrl, { pageId: page.id });

--- a/lib/validate-snap.ts
+++ b/lib/validate-snap.ts
@@ -1,0 +1,70 @@
+import { validateSnapResponse, snapResponseSchema } from '@farcaster/snap';
+import { snapJsonRenderCatalog } from '@farcaster/snap/ui';
+import { docToSnap } from './snap-spec';
+import type { SnapDoc } from './blocks';
+
+export interface ValidatePageResult {
+  pageId: string;
+  ok: boolean;
+  issues: string[];
+}
+
+export interface ValidateDocResult {
+  ok: boolean;
+  pages: ValidatePageResult[];
+  /** Flat list of human-readable issues across all pages. */
+  errors: string[];
+}
+
+function formatIssue(issue: { path?: unknown; message: string }): string {
+  const path = Array.isArray(issue.path) ? issue.path.join('.') : '';
+  return path ? `${path}: ${issue.message}` : issue.message;
+}
+
+/**
+ * Run @farcaster/snap envelope validator + ui catalog validator against
+ * every page of the doc. Returns a flat list of issues so the builder /
+ * save endpoint can surface them before storing.
+ */
+export function validateDoc(doc: SnapDoc, baseUrl = 'https://zlank.online/api/snap/preview'): ValidateDocResult {
+  const pages: ValidatePageResult[] = [];
+  const errors: string[] = [];
+
+  for (const page of doc.pages) {
+    const issues: string[] = [];
+    let snap: unknown;
+    try {
+      snap = docToSnap(doc, baseUrl, { pageId: page.id });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'render failed';
+      issues.push(`page ${page.id}: ${msg}`);
+      pages.push({ pageId: page.id, ok: false, issues });
+      errors.push(...issues);
+      continue;
+    }
+
+    const envelope = validateSnapResponse(snap);
+    if (!envelope.valid) {
+      for (const i of envelope.issues) issues.push(`envelope: ${formatIssue(i)}`);
+    }
+
+    try {
+      const parsed = snapResponseSchema.parse(snap);
+      const cat = snapJsonRenderCatalog.validate(parsed.ui);
+      if (!cat.success) {
+        const catIssues = cat.error?.issues ?? [];
+        for (const i of catIssues) issues.push(`ui: ${formatIssue(i)}`);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'parse failed';
+      issues.push(`schema: ${msg}`);
+    }
+
+    pages.push({ pageId: page.id, ok: issues.length === 0, issues });
+    if (issues.length > 0) {
+      errors.push(...issues.map((i) => `page ${page.id}: ${i}`));
+    }
+  }
+
+  return { ok: errors.length === 0, pages, errors };
+}


### PR DESCRIPTION
## Summary
Catches invalid Snaps before they're stored. Renders every page through docToSnap, validates against @farcaster/snap envelope schema + the json-render UI catalog, returns 400 with structured issues if anything fails.

Builder surfaces the issues inline. Does NOT silently fall back to local URL-encode on 400 (that would hide the bug).

## Examples it catches
- empty `text` content (catalog requires min 1 char)
- button label > 30 chars
- invalid icon name (e.g. typo "hart" instead of "heart")
- toggle_group with < 2 or > 6 options
- slider min > max, defaultValue out of range
- any other catalog constraint

## Test plan
- [ ] Save a clean Snap from the builder -> still works
- [ ] Edit a button to have a 50-char label -> Save -> red error in builder showing the issue
- [ ] Same via curl -> 400 response w/ `issues` array