### PR TITLE
feat(analytics): per-snap views + interactions counters (closes #21)

### DIFF
--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { parseRequest } from '@farcaster/snap/server';
 import { resolveSnap } from '@/lib/resolve-snap';
 import { docToSnap } from '@/lib/snap-spec';
-import { recordVote, appendChatLog } from '@/lib/kv';
+import { recordVote, appendChatLog, bumpStat } from '@/lib/kv';
 import { evaluateGates, isGateRule, type GateResult } from '@/lib/gates';
 import { chat as llmChat } from '@/lib/llm';
 import type { SnapDoc, Block, ChartBar } from '@/lib/blocks';
@@ -167,7 +167,8 @@ export async function GET(
   // Content negotiation: Snap-aware clients ask for the snap media type.
   const accept = req.headers.get('accept') ?? '';
   if (accept.includes(SNAP_MEDIA_TYPE) || accept.includes('vnd.farcaster.snap')) {
-    // GET has no FID; gated blocks render as locked stubs.
+    // Fire-and-forget view counter (don't block render on Redis).
+    void bumpStat(encoded, 'views');
     const gateResults = await resolveGatesForPage(doc, pageId, undefined);
     return snapJsonResponse(doc, origin, encoded, pageId, gateResults);
   }
@@ -296,6 +297,9 @@ export async function POST(
   if (Object.keys(inputs).length > 0) {
     return snapJsonResponse(buildAckDoc(doc, inputs), origin, encoded, pageId);
   }
+
+  // Any POST counts as an interaction (submit, vote, gate unlock, chat, etc).
+  void bumpStat(encoded, 'interactions');
 
   // Bare submit (e.g. Unlock button on a gated block) - re-render with gates
   // evaluated against the now-known FID.

--- a/app/api/snaps/[id]/stats/route.ts
+++ b/app/api/snaps/[id]/stats/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { getStats } from '@/lib/kv';
+
+export const runtime = 'nodejs';
+
+// GET /api/snaps/{snapId}/stats -> { views, interactions, lastViewAt, lastInteractionAt }
+// Public read. No FID-level breakdown for v1.
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const stats = await getStats(id);
+  return NextResponse.json(
+    { snapId: id, ...stats },
+    {
+      headers: {
+        'cache-control': 'no-store',
+        'access-control-allow-origin': '*',
+      },
+    },
+  );
+}

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -172,6 +172,48 @@ export async function appendChatLog(
   await c.expire(key, 60 * 60 * 24 * 90);
 }
 
+const STATS_PREFIX = 'stats:';
+
+export interface SnapStats {
+  views: number;
+  interactions: number;
+  lastViewAt: number | null;
+  lastInteractionAt: number | null;
+}
+
+export async function bumpStat(
+  snapId: string,
+  field: 'views' | 'interactions',
+): Promise<void> {
+  const c = await getClient();
+  if (!c) return;
+  const key = STATS_PREFIX + snapId;
+  const tsField = field === 'views' ? 'lastViewAt' : 'lastInteractionAt';
+  await Promise.all([
+    c.hIncrBy(key, field, 1),
+    c.hSet(key, tsField, String(Date.now())),
+    c.expire(key, 60 * 60 * 24 * 365),
+  ]);
+}
+
+export async function getStats(snapId: string): Promise<SnapStats> {
+  const c = await getClient();
+  const empty: SnapStats = {
+    views: 0,
+    interactions: 0,
+    lastViewAt: null,
+    lastInteractionAt: null,
+  };
+  if (!c) return empty;
+  const raw = await c.hGetAll(STATS_PREFIX + snapId);
+  return {
+    views: Number(raw.views ?? 0),
+    interactions: Number(raw.interactions ?? 0),
+    lastViewAt: raw.lastViewAt ? Number(raw.lastViewAt) : null,
+    lastInteractionAt: raw.lastInteractionAt ? Number(raw.lastInteractionAt) : null,
+  };
+}
+
 export async function getChatLog(
   snapId: string,
   limit = 50,


### PR DESCRIPTION
Counters live at GET /api/snaps/{id}/stats. Bump fire-and-forget on snap GET (views) + POST (interactions). Redis HASH, 1y TTL.