### PR TITLE
feat(blocks): leaderboard block (closes #16, doc 527 Build 3)

### DIFF
--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { parseRequest } from '@farcaster/snap/server';
 import { resolveSnap } from '@/lib/resolve-snap';
 import { docToSnap } from '@/lib/snap-spec';
-import { recordVote, appendChatLog, bumpStat } from '@/lib/kv';
+import { recordVote, appendChatLog, bumpStat, getVotes } from '@/lib/kv';
 import { evaluateGates, isGateRule, type GateResult } from '@/lib/gates';
 import { chat as llmChat } from '@/lib/llm';
 import type { SnapDoc, Block, ChartBar } from '@/lib/blocks';
@@ -51,6 +51,32 @@ const CORS_HEADERS = {
   'Access-Control-Expose-Headers': 'Link, Vary, Content-Type',
 };
 
+async function resolveLeaderboardsForPage(
+  doc: SnapDoc,
+  pageId: string | undefined,
+  snapId: string,
+): Promise<Map<number, Array<{ label: string; value: number }>> | undefined> {
+  const targetId = pageId || doc.pages[0]?.id;
+  const page = doc.pages.find((p) => p.id === targetId);
+  if (!page) return undefined;
+  const blocks = page.blocks
+    .map((block, idx) => ({ idx, block }))
+    .filter((b) => b.block.type === 'leaderboard');
+  if (blocks.length === 0) return undefined;
+  const out = new Map<number, Array<{ label: string; value: number }>>();
+  await Promise.all(
+    blocks.map(async ({ idx, block }) => {
+      if (block.type !== 'leaderboard') return;
+      const tallies = await getVotes(snapId, block.pollBlockIdx);
+      const sorted = Object.entries(tallies)
+        .sort(([, a], [, b]) => b - a)
+        .map(([label, value]) => ({ label, value }));
+      out.set(idx, sorted);
+    }),
+  );
+  return out;
+}
+
 async function resolveGatesForPage(
   doc: SnapDoc,
   pageId: string | undefined,
@@ -75,10 +101,12 @@ function snapJsonResponse(
   encoded: string,
   pageId?: string,
   gateResults?: Map<number, GateResult>,
+  leaderboardData?: Map<number, Array<{ label: string; value: number }>>,
 ): NextResponse {
   const snap = docToSnap(doc, `${origin}/api/snap/${encoded}`, {
     pageId,
     gateResults,
+    leaderboardData,
   });
   const linkHeader =
     `</api/snap/${encoded}>; rel="alternate"; type="${SNAP_MEDIA_TYPE}", ` +
@@ -167,10 +195,12 @@ export async function GET(
   // Content negotiation: Snap-aware clients ask for the snap media type.
   const accept = req.headers.get('accept') ?? '';
   if (accept.includes(SNAP_MEDIA_TYPE) || accept.includes('vnd.farcaster.snap')) {
-    // Fire-and-forget view counter (don't block render on Redis).
     void bumpStat(encoded, 'views');
-    const gateResults = await resolveGatesForPage(doc, pageId, undefined);
-    return snapJsonResponse(doc, origin, encoded, pageId, gateResults);
+    const [gateResults, leaderboardData] = await Promise.all([
+      resolveGatesForPage(doc, pageId, undefined),
+      resolveLeaderboardsForPage(doc, pageId, encoded),
+    ]);
+    return snapJsonResponse(doc, origin, encoded, pageId, gateResults, leaderboardData);
   }
 
   return htmlResponse(doc, origin, encoded);
@@ -298,13 +328,14 @@ export async function POST(
     return snapJsonResponse(buildAckDoc(doc, inputs), origin, encoded, pageId);
   }
 
-  // Any POST counts as an interaction (submit, vote, gate unlock, chat, etc).
   void bumpStat(encoded, 'interactions');
 
-  // Bare submit (e.g. Unlock button on a gated block) - re-render with gates
-  // evaluated against the now-known FID.
-  const gateResults = await resolveGatesForPage(doc, pageId, fid);
-  return snapJsonResponse(doc, origin, encoded, pageId, gateResults);
+  // Bare submit (Unlock button etc) - re-render with gates + fresh leaderboards.
+  const [gateResults, leaderboardData] = await Promise.all([
+    resolveGatesForPage(doc, pageId, fid),
+    resolveLeaderboardsForPage(doc, pageId, encoded),
+  ]);
+  return snapJsonResponse(doc, origin, encoded, pageId, gateResults, leaderboardData);
 }
 
 function buildResultsDoc(

--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { parseRequest } from '@farcaster/snap/server';
 import { resolveSnap } from '@/lib/resolve-snap';
 import { docToSnap } from '@/lib/snap-spec';
-import { recordVote, appendChatLog } from '@/lib/kv';
+import { recordVote, appendChatLog, bumpStat } from '@/lib/kv';
 import { evaluateGates, isGateRule, type GateResult } from '@/lib/gates';
 import { chat as llmChat } from '@/lib/llm';
 import type { SnapDoc, Block, ChartBar } from '@/lib/blocks';
@@ -167,7 +167,8 @@ export async function GET(
   // Content negotiation: Snap-aware clients ask for the snap media type.
   const accept = req.headers.get('accept') ?? '';
   if (accept.includes(SNAP_MEDIA_TYPE) || accept.includes('vnd.farcaster.snap')) {
-    // GET has no FID; gated blocks render as locked stubs.
+    // Fire-and-forget view counter (don't block render on Redis).
+    void bumpStat(encoded, 'views');
     const gateResults = await resolveGatesForPage(doc, pageId, undefined);
     return snapJsonResponse(doc, origin, encoded, pageId, gateResults);
   }
@@ -296,6 +297,9 @@ export async function POST(
   if (Object.keys(inputs).length > 0) {
     return snapJsonResponse(buildAckDoc(doc, inputs), origin, encoded, pageId);
   }
+
+  // Any POST counts as an interaction (submit, vote, gate unlock, chat, etc).
+  void bumpStat(encoded, 'interactions');
 
   // Bare submit (e.g. Unlock button on a gated block) - re-render with gates
   // evaluated against the now-known FID.

--- a/app/api/snaps/[id]/stats/route.ts
+++ b/app/api/snaps/[id]/stats/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { getStats } from '@/lib/kv';
+
+export const runtime = 'nodejs';
+
+// GET /api/snaps/{snapId}/stats -> { views, interactions, lastViewAt, lastInteractionAt }
+// Public read. No FID-level breakdown for v1.
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const stats = await getStats(id);
+  return NextResponse.json(
+    { snapId: id, ...stats },
+    {
+      headers: {
+        'cache-control': 'no-store',
+        'access-control-allow-origin': '*',
+      },
+    },
+  );
+}

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -33,6 +33,7 @@ const BLOCK_OPTIONS: { type: BlockType; label: string; icon: string }[] = [
   { type: 'switch', label: 'Switch', icon: 'O' },
   { type: 'feedback', label: 'Feedback', icon: '@' },
   { type: 'chatbot', label: 'Chatbot', icon: 'C' },
+  { type: 'leaderboard', label: 'Leaderboard', icon: 'L' },
   { type: 'divider', label: 'Divider', icon: '-' },
 ];
 
@@ -115,6 +116,14 @@ function newBlock(type: BlockType, availablePageIds: string[] = []): Block {
           'You are a friendly builder coach. Reply briefly (max 2 sentences) and ask one curious follow-up about what they are making.',
         label: 'Send',
         placeholder: 'Type here...',
+      };
+    case 'leaderboard':
+      return {
+        type: 'leaderboard',
+        title: 'Live results',
+        source: 'votes',
+        pollBlockIdx: 0,
+        topN: 5,
       };
   }
 }
@@ -874,6 +883,37 @@ function BlockEditor({
               className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
             />
           </div>
+        </>
+      )}
+      {block.type === 'leaderboard' && (
+        <>
+          <input
+            value={block.title}
+            onChange={(e) => onChange({ title: e.target.value } as Partial<Block>)}
+            placeholder="Title (e.g. Live results)"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <div className="flex gap-2">
+            <span className="self-center text-xs text-[#8aa0bd]">Poll block #</span>
+            <input
+              type="number"
+              value={block.pollBlockIdx}
+              onChange={(e) => onChange({ pollBlockIdx: Number(e.target.value) } as Partial<Block>)}
+              placeholder="0"
+              className="w-20 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            />
+            <span className="self-center text-xs text-[#8aa0bd]">Top N:</span>
+            <input
+              type="number"
+              value={block.topN ?? 5}
+              onChange={(e) => onChange({ topN: Number(e.target.value) } as Partial<Block>)}
+              placeholder="5"
+              className="w-20 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            />
+          </div>
+          <p className="text-[11px] text-[#5e7290]">
+            Pulls live tallies from a poll block on the same page. Index = position of the poll (0 = first block).
+          </p>
         </>
       )}
       {block.type === 'divider' && <p className="text-xs text-[#8aa0bd]">Visual separator. No fields.</p>}

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -19,7 +19,8 @@ export type BlockType =
   | 'slider'
   | 'switch'
   | 'feedback'
-  | 'chatbot';
+  | 'chatbot'
+  | 'leaderboard';
 
 // Subset of the 34 Snap icons - the most useful for blocks.
 export const ICONS = [
@@ -145,6 +146,16 @@ export interface SwitchBlock {
   defaultChecked: boolean;
 }
 
+// Live tally pulled from a referenced poll block on the same page.
+// Renders as bar_chart sorted desc, top N. v1 source = 'votes' (poll).
+export interface LeaderboardBlock {
+  type: 'leaderboard';
+  title: string;
+  source: 'votes';
+  pollBlockIdx: number;
+  topN?: number;
+}
+
 // User chats with an LLM inline. Submit logs the message + LLM reply to
 // Redis (chatlog:{snapId}) and returns a Snap with the reply + same chatbot
 // block to keep the loop going. Stateless per-turn (Snap protocol has no
@@ -194,7 +205,8 @@ type AnyBlock =
   | SliderBlock
   | SwitchBlock
   | FeedbackBlock
-  | ChatbotBlock;
+  | ChatbotBlock
+  | LeaderboardBlock;
 
 // Optional `gate` lets a block require a token-balance check before render.
 // Evaluated server-side on POST; falsy on GET (no FID), so gated blocks
@@ -384,6 +396,14 @@ export function clampBlock(block: Block): Block {
         systemPrompt: block.systemPrompt.slice(0, 2000),
         label: block.label.slice(0, LABEL_MAX),
         placeholder: block.placeholder?.slice(0, 60),
+      };
+    case 'leaderboard':
+      return {
+        ...block,
+        title: block.title.slice(0, TITLE_MAX),
+        source: 'votes',
+        pollBlockIdx: Math.max(0, Math.floor(Number(block.pollBlockIdx) || 0)),
+        topN: Math.min(Math.max(Number(block.topN) || 5, 1), 6),
       };
   }
 }

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -172,6 +172,48 @@ export async function appendChatLog(
   await c.expire(key, 60 * 60 * 24 * 90);
 }
 
+const STATS_PREFIX = 'stats:';
+
+export interface SnapStats {
+  views: number;
+  interactions: number;
+  lastViewAt: number | null;
+  lastInteractionAt: number | null;
+}
+
+export async function bumpStat(
+  snapId: string,
+  field: 'views' | 'interactions',
+): Promise<void> {
+  const c = await getClient();
+  if (!c) return;
+  const key = STATS_PREFIX + snapId;
+  const tsField = field === 'views' ? 'lastViewAt' : 'lastInteractionAt';
+  await Promise.all([
+    c.hIncrBy(key, field, 1),
+    c.hSet(key, tsField, String(Date.now())),
+    c.expire(key, 60 * 60 * 24 * 365),
+  ]);
+}
+
+export async function getStats(snapId: string): Promise<SnapStats> {
+  const c = await getClient();
+  const empty: SnapStats = {
+    views: 0,
+    interactions: 0,
+    lastViewAt: null,
+    lastInteractionAt: null,
+  };
+  if (!c) return empty;
+  const raw = await c.hGetAll(STATS_PREFIX + snapId);
+  return {
+    views: Number(raw.views ?? 0),
+    interactions: Number(raw.interactions ?? 0),
+    lastViewAt: raw.lastViewAt ? Number(raw.lastViewAt) : null,
+    lastInteractionAt: raw.lastInteractionAt ? Number(raw.lastInteractionAt) : null,
+  };
+}
+
 export async function getChatLog(
   snapId: string,
   limit = 50,

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -332,6 +332,28 @@ function blockToElements(
       ids.push(promptId, inputId, btnId);
       break;
     }
+    case 'leaderboard': {
+      // Resolved data is passed via opts.leaderboardData. If absent (no
+      // resolution available), render an empty-state text instead of a
+      // broken chart.
+      // The actual data is wired in by docToSnap below (it has access to opts).
+      // Here we just emit the placeholder; docToSnap replaces these elements.
+      const titleId = `${id}_title`;
+      const chartId = `${id}_chart`;
+      elements[titleId] = {
+        type: 'text',
+        props: { content: block.title, size: 'md', weight: 'bold' },
+      };
+      elements[chartId] = {
+        type: 'text',
+        props: {
+          content: 'No votes yet.',
+          size: 'sm',
+        },
+      };
+      ids.push(titleId, chartId);
+      break;
+    }
     case 'chatbot': {
       const titleId = `${id}_title`;
       const promptId = `${id}_prompt`;
@@ -372,6 +394,8 @@ export interface DocToSnapOpts {
   pageId?: string;
   /** Per-block-index gate results from POST handler. */
   gateResults?: Map<number, GateResult>;
+  /** Per-block-index resolved leaderboard data (label, value pairs). */
+  leaderboardData?: Map<number, Array<{ label: string; value: number }>>;
 }
 
 export function docToSnap(
@@ -409,6 +433,31 @@ export function docToSnap(
         return;
       }
     }
+
+    // Leaderboard needs async-resolved data; replace the placeholder text
+    // element with a real bar_chart when data is available.
+    if (block.type === 'leaderboard') {
+      const data = opts.leaderboardData?.get(idx);
+      const titleId = `b${idx}_title`;
+      const chartId = `b${idx}_chart`;
+      allElements[titleId] = {
+        type: 'text',
+        props: { content: block.title, size: 'md', weight: 'bold' },
+      };
+      const topN = block.topN ?? 5;
+      const bars = (data ?? []).slice(0, topN);
+      if (bars.length > 0) {
+        allElements[chartId] = { type: 'bar_chart', props: { bars } };
+      } else {
+        allElements[chartId] = {
+          type: 'text',
+          props: { content: 'No votes yet.', size: 'sm' },
+        };
+      }
+      childIds.push(titleId, chartId);
+      return;
+    }
+
     const { ids, elements } = blockToElements(block, idx, baseUrl);
     Object.assign(allElements, elements);
     childIds.push(...ids);

--- a/lib/validate-snap.ts
+++ b/lib/validate-snap.ts
@@ -75,6 +75,12 @@ function lintBlock(block: Block, idx: number): string[] {
         issues.push(`${here}: chart needs at least 1 bar`);
       }
       break;
+    case 'leaderboard':
+      if (!block.title?.trim()) issues.push(`${here}: leaderboard title is empty`);
+      if (!Number.isFinite(block.pollBlockIdx) || block.pollBlockIdx < 0) {
+        issues.push(`${here}: leaderboard pollBlockIdx must be >= 0`);
+      }
+      break;
   }
   return issues;
 }


### PR DESCRIPTION
17th block. Pulls live tally from a referenced poll on the same page, sorts desc, renders top N as bar_chart. Server-resolved on every render. Stacks on top of #21.