### PR TITLE
feat(coin): per-snap creator coin auto-injects swap button (closes #15, doc 527 Build 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ MINIMAX_API_URL=
 MINIMAX_MODEL=
 ANTHROPIC_API_KEY=
 ANTHROPIC_MODEL=
+
+# Optional: Vercel Blob token for image upload block. Auto-set when you
+# add the Vercel Blob integration to the project. Without it, the image
+# upload button returns 503 (paste image URL manually).
+BLOB_READ_WRITE_TOKEN=

--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { parseRequest } from '@farcaster/snap/server';
 import { resolveSnap } from '@/lib/resolve-snap';
 import { docToSnap } from '@/lib/snap-spec';
-import { recordVote, appendChatLog, bumpStat } from '@/lib/kv';
+import { recordVote, appendChatLog, bumpStat, getVotes } from '@/lib/kv';
 import { evaluateGates, isGateRule, type GateResult } from '@/lib/gates';
 import { chat as llmChat } from '@/lib/llm';
 import type { SnapDoc, Block, ChartBar } from '@/lib/blocks';
@@ -51,6 +51,32 @@ const CORS_HEADERS = {
   'Access-Control-Expose-Headers': 'Link, Vary, Content-Type',
 };
 
+async function resolveLeaderboardsForPage(
+  doc: SnapDoc,
+  pageId: string | undefined,
+  snapId: string,
+): Promise<Map<number, Array<{ label: string; value: number }>> | undefined> {
+  const targetId = pageId || doc.pages[0]?.id;
+  const page = doc.pages.find((p) => p.id === targetId);
+  if (!page) return undefined;
+  const blocks = page.blocks
+    .map((block, idx) => ({ idx, block }))
+    .filter((b) => b.block.type === 'leaderboard');
+  if (blocks.length === 0) return undefined;
+  const out = new Map<number, Array<{ label: string; value: number }>>();
+  await Promise.all(
+    blocks.map(async ({ idx, block }) => {
+      if (block.type !== 'leaderboard') return;
+      const tallies = await getVotes(snapId, block.pollBlockIdx);
+      const sorted = Object.entries(tallies)
+        .sort(([, a], [, b]) => b - a)
+        .map(([label, value]) => ({ label, value }));
+      out.set(idx, sorted);
+    }),
+  );
+  return out;
+}
+
 async function resolveGatesForPage(
   doc: SnapDoc,
   pageId: string | undefined,
@@ -75,10 +101,12 @@ function snapJsonResponse(
   encoded: string,
   pageId?: string,
   gateResults?: Map<number, GateResult>,
+  leaderboardData?: Map<number, Array<{ label: string; value: number }>>,
 ): NextResponse {
   const snap = docToSnap(doc, `${origin}/api/snap/${encoded}`, {
     pageId,
     gateResults,
+    leaderboardData,
   });
   const linkHeader =
     `</api/snap/${encoded}>; rel="alternate"; type="${SNAP_MEDIA_TYPE}", ` +
@@ -167,10 +195,12 @@ export async function GET(
   // Content negotiation: Snap-aware clients ask for the snap media type.
   const accept = req.headers.get('accept') ?? '';
   if (accept.includes(SNAP_MEDIA_TYPE) || accept.includes('vnd.farcaster.snap')) {
-    // Fire-and-forget view counter (don't block render on Redis).
     void bumpStat(encoded, 'views');
-    const gateResults = await resolveGatesForPage(doc, pageId, undefined);
-    return snapJsonResponse(doc, origin, encoded, pageId, gateResults);
+    const [gateResults, leaderboardData] = await Promise.all([
+      resolveGatesForPage(doc, pageId, undefined),
+      resolveLeaderboardsForPage(doc, pageId, encoded),
+    ]);
+    return snapJsonResponse(doc, origin, encoded, pageId, gateResults, leaderboardData);
   }
 
   return htmlResponse(doc, origin, encoded);
@@ -298,13 +328,14 @@ export async function POST(
     return snapJsonResponse(buildAckDoc(doc, inputs), origin, encoded, pageId);
   }
 
-  // Any POST counts as an interaction (submit, vote, gate unlock, chat, etc).
   void bumpStat(encoded, 'interactions');
 
-  // Bare submit (e.g. Unlock button on a gated block) - re-render with gates
-  // evaluated against the now-known FID.
-  const gateResults = await resolveGatesForPage(doc, pageId, fid);
-  return snapJsonResponse(doc, origin, encoded, pageId, gateResults);
+  // Bare submit (Unlock button etc) - re-render with gates + fresh leaderboards.
+  const [gateResults, leaderboardData] = await Promise.all([
+    resolveGatesForPage(doc, pageId, fid),
+    resolveLeaderboardsForPage(doc, pageId, encoded),
+  ]);
+  return snapJsonResponse(doc, origin, encoded, pageId, gateResults, leaderboardData);
 }
 
 function buildResultsDoc(

--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -195,7 +195,7 @@ export async function GET(
   // Content negotiation: Snap-aware clients ask for the snap media type.
   const accept = req.headers.get('accept') ?? '';
   if (accept.includes(SNAP_MEDIA_TYPE) || accept.includes('vnd.farcaster.snap')) {
-    void bumpStat(encoded, 'views');
+    bumpStat(encoded, 'views').catch((err) => console.error('bumpStat views', err));
     const [gateResults, leaderboardData] = await Promise.all([
       resolveGatesForPage(doc, pageId, undefined),
       resolveLeaderboardsForPage(doc, pageId, encoded),
@@ -328,7 +328,9 @@ export async function POST(
     return snapJsonResponse(buildAckDoc(doc, inputs), origin, encoded, pageId);
   }
 
-  void bumpStat(encoded, 'interactions');
+  bumpStat(encoded, 'interactions').catch((err) =>
+    console.error('bumpStat interactions', err),
+  );
 
   // Bare submit (Unlock button etc) - re-render with gates + fresh leaderboards.
   const [gateResults, leaderboardData] = await Promise.all([

--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { parseRequest } from '@farcaster/snap/server';
 import { resolveSnap } from '@/lib/resolve-snap';
 import { docToSnap } from '@/lib/snap-spec';
-import { recordVote, appendChatLog } from '@/lib/kv';
+import { recordVote, appendChatLog, bumpStat } from '@/lib/kv';
 import { evaluateGates, isGateRule, type GateResult } from '@/lib/gates';
 import { chat as llmChat } from '@/lib/llm';
 import type { SnapDoc, Block, ChartBar } from '@/lib/blocks';
@@ -167,7 +167,8 @@ export async function GET(
   // Content negotiation: Snap-aware clients ask for the snap media type.
   const accept = req.headers.get('accept') ?? '';
   if (accept.includes(SNAP_MEDIA_TYPE) || accept.includes('vnd.farcaster.snap')) {
-    // GET has no FID; gated blocks render as locked stubs.
+    // Fire-and-forget view counter (don't block render on Redis).
+    void bumpStat(encoded, 'views');
     const gateResults = await resolveGatesForPage(doc, pageId, undefined);
     return snapJsonResponse(doc, origin, encoded, pageId, gateResults);
   }
@@ -296,6 +297,9 @@ export async function POST(
   if (Object.keys(inputs).length > 0) {
     return snapJsonResponse(buildAckDoc(doc, inputs), origin, encoded, pageId);
   }
+
+  // Any POST counts as an interaction (submit, vote, gate unlock, chat, etc).
+  void bumpStat(encoded, 'interactions');
 
   // Bare submit (e.g. Unlock button on a gated block) - re-render with gates
   // evaluated against the now-known FID.

--- a/app/api/snaps/[id]/coin/route.ts
+++ b/app/api/snaps/[id]/coin/route.ts
@@ -10,7 +10,8 @@ export const runtime = 'nodejs';
 // Updates BOTH the runtime snap key and the editable snapdoc key in Redis
 // so the swap_token button auto-injects on next render.
 
-const CAIP19_RE = /^eip155:\d+\/erc20:0x[a-fA-F0-9]{40}$/;
+// Allowed chain IDs: Ethereum mainnet, Base, Optimism, Polygon, Arbitrum, Zora.
+const CAIP19_RE = /^eip155:(1|8453|10|137|42161|7777777)\/erc20:0x[a-fA-F0-9]{40}$/;
 
 export async function POST(
   req: NextRequest,
@@ -25,18 +26,25 @@ export async function POST(
   }
 
   if (body.clear) {
-    const ok = await setSnapCoin(id, null);
-    return NextResponse.json({ ok, cleared: true });
+    const r = await setSnapCoin(id, null);
+    if (r.missing) return NextResponse.json({ error: 'snap not found' }, { status: 404 });
+    if (r.updated === 0) return NextResponse.json({ error: 'snap corrupt' }, { status: 500 });
+    return NextResponse.json({ ok: true, cleared: true, updated: r.updated });
   }
 
   const caip19 = body.caip19?.trim();
   if (!caip19 || !CAIP19_RE.test(caip19)) {
     return NextResponse.json(
-      { error: 'caip19 required, format eip155:CHAINID/erc20:0xADDRESS' },
+      {
+        error:
+          'caip19 required, format eip155:{1|8453|10|137|42161|7777777}/erc20:0xADDRESS',
+      },
       { status: 400 },
     );
   }
-  const symbol = body.symbol?.trim().slice(0, 24);
-  const ok = await setSnapCoin(id, { caip19, symbol });
-  return NextResponse.json({ ok, coin: { caip19, symbol } });
+  const symbol = body.symbol?.trim().slice(0, 12);
+  const r = await setSnapCoin(id, { caip19, symbol });
+  if (r.missing) return NextResponse.json({ error: 'snap not found' }, { status: 404 });
+  if (r.updated === 0) return NextResponse.json({ error: 'snap corrupt' }, { status: 500 });
+  return NextResponse.json({ ok: true, updated: r.updated, coin: { caip19, symbol } });
 }

--- a/app/api/snaps/[id]/coin/route.ts
+++ b/app/api/snaps/[id]/coin/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { setSnapCoin } from '@/lib/kv';
+
+export const runtime = 'nodejs';
+
+// POST /api/snaps/{id}/coin
+// Body: { caip19: "eip155:8453/erc20:0x...", symbol?: "MYTOKEN" }
+// or:   { clear: true } to remove the coin association.
+//
+// Updates BOTH the runtime snap key and the editable snapdoc key in Redis
+// so the swap_token button auto-injects on next render.
+
+const CAIP19_RE = /^eip155:\d+\/erc20:0x[a-fA-F0-9]{40}$/;
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ id: string }> },
+) {
+  const { id } = await ctx.params;
+  let body: { caip19?: string; symbol?: string; clear?: boolean };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  if (body.clear) {
+    const ok = await setSnapCoin(id, null);
+    return NextResponse.json({ ok, cleared: true });
+  }
+
+  const caip19 = body.caip19?.trim();
+  if (!caip19 || !CAIP19_RE.test(caip19)) {
+    return NextResponse.json(
+      { error: 'caip19 required, format eip155:CHAINID/erc20:0xADDRESS' },
+      { status: 400 },
+    );
+  }
+  const symbol = body.symbol?.trim().slice(0, 24);
+  const ok = await setSnapCoin(id, { caip19, symbol });
+  return NextResponse.json({ ok, coin: { caip19, symbol } });
+}

--- a/app/api/snaps/[id]/stats/route.ts
+++ b/app/api/snaps/[id]/stats/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { getStats } from '@/lib/kv';
+
+export const runtime = 'nodejs';
+
+// GET /api/snaps/{snapId}/stats -> { views, interactions, lastViewAt, lastInteractionAt }
+// Public read. No FID-level breakdown for v1.
+
+export async function GET(_req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  const stats = await getStats(id);
+  return NextResponse.json(
+    { snapId: id, ...stats },
+    {
+      headers: {
+        'cache-control': 'no-store',
+        'access-control-allow-origin': '*',
+      },
+    },
+  );
+}

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { put } from '@vercel/blob';
+import { nanoid } from 'nanoid';
+
+export const runtime = 'nodejs';
+
+// POST /api/upload  multipart/form-data with field "file"
+// Returns { url } pointing at a public Vercel Blob URL.
+// Requires BLOB_READ_WRITE_TOKEN env (auto when Vercel Blob added to project).
+
+const MAX_BYTES = 4 * 1024 * 1024; // 4 MiB
+const ALLOWED = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
+
+export async function POST(req: NextRequest) {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    return NextResponse.json(
+      { error: 'Image upload disabled - BLOB_READ_WRITE_TOKEN not set on server.' },
+      { status: 503 },
+    );
+  }
+
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch {
+    return NextResponse.json({ error: 'multipart/form-data required' }, { status: 400 });
+  }
+
+  const file = form.get('file');
+  if (!(file instanceof Blob)) {
+    return NextResponse.json({ error: 'missing file field' }, { status: 400 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json(
+      { error: `file too large (max ${MAX_BYTES} bytes)` },
+      { status: 413 },
+    );
+  }
+  if (file.type && !ALLOWED.includes(file.type)) {
+    return NextResponse.json(
+      { error: `unsupported type ${file.type}` },
+      { status: 415 },
+    );
+  }
+
+  const ext = (file.type.split('/')[1] || 'bin').replace(/\W/g, '');
+  const key = `zlank/images/${nanoid(10)}.${ext}`;
+  try {
+    const blob = await put(key, file, {
+      access: 'public',
+      addRandomSuffix: false,
+      contentType: file.type || 'application/octet-stream',
+    });
+    return NextResponse.json({ url: blob.url });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'upload failed';
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -33,6 +33,7 @@ const BLOCK_OPTIONS: { type: BlockType; label: string; icon: string }[] = [
   { type: 'switch', label: 'Switch', icon: 'O' },
   { type: 'feedback', label: 'Feedback', icon: '@' },
   { type: 'chatbot', label: 'Chatbot', icon: 'C' },
+  { type: 'leaderboard', label: 'Leaderboard', icon: 'L' },
   { type: 'divider', label: 'Divider', icon: '-' },
 ];
 
@@ -115,6 +116,14 @@ function newBlock(type: BlockType, availablePageIds: string[] = []): Block {
           'You are a friendly builder coach. Reply briefly (max 2 sentences) and ask one curious follow-up about what they are making.',
         label: 'Send',
         placeholder: 'Type here...',
+      };
+    case 'leaderboard':
+      return {
+        type: 'leaderboard',
+        title: 'Live results',
+        source: 'votes',
+        pollBlockIdx: 0,
+        topN: 5,
       };
   }
 }
@@ -874,6 +883,37 @@ function BlockEditor({
               className="flex-1 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
             />
           </div>
+        </>
+      )}
+      {block.type === 'leaderboard' && (
+        <>
+          <input
+            value={block.title}
+            onChange={(e) => onChange({ title: e.target.value } as Partial<Block>)}
+            placeholder="Title (e.g. Live results)"
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+          />
+          <div className="flex gap-2">
+            <span className="self-center text-xs text-[#8aa0bd]">Poll block #</span>
+            <input
+              type="number"
+              value={block.pollBlockIdx}
+              onChange={(e) => onChange({ pollBlockIdx: Number(e.target.value) } as Partial<Block>)}
+              placeholder="0"
+              className="w-20 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            />
+            <span className="self-center text-xs text-[#8aa0bd]">Top N:</span>
+            <input
+              type="number"
+              value={block.topN ?? 5}
+              onChange={(e) => onChange({ topN: Number(e.target.value) } as Partial<Block>)}
+              placeholder="5"
+              className="w-20 bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
+            />
+          </div>
+          <p className="text-[11px] text-[#5e7290]">
+            Pulls live tallies from a poll block on the same page. Index = position of the poll (0 = first block).
+          </p>
         </>
       )}
       {block.type === 'divider' && <p className="text-xs text-[#8aa0bd]">Visual separator. No fields.</p>}

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -404,6 +404,43 @@ export default function Builder() {
             Confetti effect on render
           </label>
 
+          <details className="border border-[#1f3252] rounded">
+            <summary className="cursor-pointer px-2 py-1 text-xs text-[#8aa0bd] hover:text-[#f5a623]">
+              Coin {doc.coin?.caip19 ? `(buy $${doc.coin.symbol || 'token'} button auto-injected)` : '(none)'}
+            </summary>
+            <div className="p-2 space-y-2 text-xs">
+              <input
+                value={doc.coin?.caip19 ?? ''}
+                onChange={(e) => {
+                  const v = e.target.value.trim();
+                  setDoc((d) => ({
+                    ...d,
+                    coin: v ? { ...(d.coin ?? {}), caip19: v } : undefined,
+                  }));
+                }}
+                placeholder="CAIP-19 (e.g. eip155:8453/erc20:0x...)"
+                className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1"
+              />
+              <input
+                value={doc.coin?.symbol ?? ''}
+                onChange={(e) => {
+                  const v = e.target.value.trim();
+                  setDoc((d) => ({
+                    ...d,
+                    coin: d.coin ? { ...d.coin, symbol: v } : undefined,
+                  }));
+                }}
+                placeholder="Symbol (e.g. ZBL)"
+                className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1"
+                disabled={!doc.coin?.caip19}
+              />
+              <p className="text-[11px] text-[#5e7290]">
+                When set, every page auto-prepends a "Buy ${doc.coin?.symbol || 'token'}" button using the Snap{' '}
+                <code>swap_token</code> action. Launch a coin via Zora/Clanker/Empire Builder, then paste the CAIP-19 here.
+              </p>
+            </div>
+          </details>
+
           <div className="border-t border-[#1f3252] pt-3 space-y-2">
             <div className="flex items-center justify-between">
               <h3 className="text-xs text-[#8aa0bd] uppercase tracking-wide">Pages</h3>

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -629,10 +629,14 @@ function BlockEditor({
 
       {block.type === 'image' && (
         <>
+          <ImageUploader
+            currentUrl={block.url}
+            onUploaded={(url) => onChange({ url } as Partial<Block>)}
+          />
           <input
             value={block.url}
             onChange={(e) => onChange({ url: e.target.value } as Partial<Block>)}
-            placeholder="https://image.url"
+            placeholder="https://image.url (or upload above)"
             className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-2 py-1 text-sm"
           />
           <input
@@ -919,6 +923,68 @@ function BlockEditor({
       {block.type === 'divider' && <p className="text-xs text-[#8aa0bd]">Visual separator. No fields.</p>}
 
       <GateEditor block={block} onChange={onChange} />
+    </div>
+  );
+}
+
+function ImageUploader({
+  currentUrl,
+  onUploaded,
+}: {
+  currentUrl: string;
+  onUploaded: (url: string) => void;
+}) {
+  const [uploading, setUploading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function handleFile(file: File) {
+    setUploading(true);
+    setErr(null);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      const res = await fetch('/api/upload', { method: 'POST', body: fd });
+      const data = (await res.json()) as { url?: string; error?: string };
+      if (!res.ok || !data.url) {
+        throw new Error(data.error ?? `HTTP ${res.status}`);
+      }
+      onUploaded(data.url);
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <label className="px-2 py-1 bg-[#0a1628] border border-[#1f3252] rounded text-xs cursor-pointer hover:bg-[#1f3252]">
+          {uploading ? 'Uploading...' : 'Upload image'}
+          <input
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) handleFile(f);
+              e.target.value = '';
+            }}
+            disabled={uploading}
+            className="hidden"
+          />
+        </label>
+        {currentUrl && (
+          <a
+            href={currentUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-xs text-[#8aa0bd] underline truncate max-w-[180px]"
+          >
+            {currentUrl.replace(/^https?:\/\//, '').slice(0, 40)}
+          </a>
+        )}
+      </div>
+      {err && <p className="text-[11px] text-red-400">{err}</p>}
     </div>
   );
 }

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -975,6 +975,16 @@ function ImageUploader({
   const [err, setErr] = useState<string | null>(null);
 
   async function handleFile(file: File) {
+    const MAX = 4 * 1024 * 1024;
+    const ALLOWED = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
+    if (file.size > MAX) {
+      setErr(`File too large (${Math.round(file.size / 1024)} KB, max 4 MB)`);
+      return;
+    }
+    if (file.type && !ALLOWED.includes(file.type)) {
+      setErr(`Unsupported type: ${file.type}`);
+      return;
+    }
     setUploading(true);
     setErr(null);
     try {

--- a/app/s/[encoded]/page.tsx
+++ b/app/s/[encoded]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { resolveSnap } from '@/lib/resolve-snap';
-import type { Block, SnapDoc } from '@/lib/blocks';
+import { getVotes } from '@/lib/kv';
+import type { Block, SnapDoc, ChartBar } from '@/lib/blocks';
 import type { Metadata } from 'next';
 
 interface PageProps {
@@ -60,11 +61,36 @@ export default async function SnapViewer({ params, searchParams }: SnapViewerPro
   const currentPage = doc.pages.find((p) => p.id === currentPageId);
   const blocks = currentPage?.blocks ?? doc.pages[0]?.blocks ?? [];
 
+  // Resolve leaderboard data on the server (parity with the inline Snap).
+  const leaderboardEntries = blocks
+    .map((b, idx) => ({ b, idx }))
+    .filter(({ b }) => b.type === 'leaderboard');
+  const leaderboardData = new Map<number, ChartBar[]>();
+  await Promise.all(
+    leaderboardEntries.map(async ({ b, idx }) => {
+      if (b.type !== 'leaderboard') return;
+      const tallies = await getVotes(encoded, b.pollBlockIdx);
+      leaderboardData.set(
+        idx,
+        Object.entries(tallies)
+          .sort(([, x], [, y]) => y - x)
+          .map(([label, value]) => ({ label, value })),
+      );
+    }),
+  );
+
   return (
     <main className="max-w-md mx-auto px-4 py-8 min-h-screen flex flex-col">
       <div className="space-y-3 flex-1">
         {blocks.map((block, i) => (
-          <BlockView key={i} block={block} accent={accent} encoded={encoded} />
+          <BlockView
+            key={i}
+            block={block}
+            accent={accent}
+            encoded={encoded}
+            idx={i}
+            leaderboardData={leaderboardData.get(i)}
+          />
         ))}
       </div>
       <footer className="mt-8 pt-4 border-t border-[#1f3252] text-xs text-[#8aa0bd] text-center">
@@ -77,7 +103,19 @@ export default async function SnapViewer({ params, searchParams }: SnapViewerPro
   );
 }
 
-function BlockView({ block, accent, encoded }: { block: Block; accent: string; encoded: string }) {
+function BlockView({
+  block,
+  accent,
+  encoded,
+  idx,
+  leaderboardData,
+}: {
+  block: Block;
+  accent: string;
+  encoded: string;
+  idx: number;
+  leaderboardData?: ChartBar[];
+}) {
   switch (block.type) {
     case 'header':
       return (
@@ -223,5 +261,117 @@ function BlockView({ block, accent, encoded }: { block: Block; accent: string; e
           <input type="checkbox" defaultChecked={block.defaultChecked} style={{ accentColor: accent }} />
         </label>
       );
+    case 'chart': {
+      const total = block.bars.reduce((s, b) => s + b.value, 0) || 1;
+      return (
+        <div className="bg-[#122440] border border-[#1f3252] rounded-lg px-4 py-3 space-y-2">
+          <div className="font-bold text-sm" style={{ color: accent }}>{block.title}</div>
+          {block.bars.map((bar, i) => {
+            const pct = (bar.value / Math.max(...block.bars.map((b) => b.value), 1)) * 100;
+            return (
+              <div key={i} className="space-y-0.5">
+                <div className="flex justify-between text-xs">
+                  <span>{bar.label}</span>
+                  <span className="text-[#8aa0bd]">{bar.value}</span>
+                </div>
+                <div className="h-2 bg-[#1f3252] rounded">
+                  <div className="h-full rounded" style={{ width: `${pct}%`, background: accent }} />
+                </div>
+              </div>
+            );
+          })}
+          <div className="text-[11px] text-[#5e7290] pt-1">total: {total}</div>
+        </div>
+      );
+    }
+    case 'toggle':
+      return (
+        <div className="bg-[#122440] border border-[#1f3252] rounded-lg px-4 py-3 space-y-2">
+          {block.label && <div className="text-sm font-bold">{block.label}</div>}
+          <div className={`flex flex-wrap gap-2 ${block.orientation === 'vertical' ? 'flex-col' : ''}`}>
+            {block.options.map((opt, i) => (
+              <button
+                key={i}
+                className="bg-[#0a1628] border border-[#1f3252] rounded px-3 py-1.5 text-sm hover:border-[#f5a623] transition"
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+        </div>
+      );
+    case 'feedback':
+      return (
+        <div className="bg-[#122440] border border-[#1f3252] rounded-lg px-4 py-3 space-y-2">
+          <div className="text-sm font-bold">{block.prompt}</div>
+          <input
+            placeholder="Type your feedback..."
+            disabled
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-3 py-2 text-sm"
+          />
+          <button
+            disabled
+            className="w-full bg-[#1f3252] text-[#8aa0bd] rounded px-3 py-2 text-sm cursor-not-allowed"
+          >
+            {block.label}
+          </button>
+          <p className="text-[11px] text-[#5e7290]">
+            Tags @{block.mention}. Send via Snap-aware Farcaster client.
+          </p>
+        </div>
+      );
+    case 'chatbot':
+      return (
+        <div className="bg-[#122440] border border-[#1f3252] rounded-lg px-4 py-3 space-y-2">
+          <div className="font-bold" style={{ color: accent }}>{block.title}</div>
+          <div className="text-xs text-[#8aa0bd]">{block.prompt}</div>
+          <input
+            placeholder={block.placeholder ?? 'Type here...'}
+            disabled
+            className="w-full bg-[#0a1628] border border-[#1f3252] rounded px-3 py-2 text-sm"
+          />
+          <button
+            disabled
+            className="w-full bg-[#1f3252] text-[#8aa0bd] rounded px-3 py-2 text-sm cursor-not-allowed"
+          >
+            {block.label}
+          </button>
+          <p className="text-[11px] text-[#5e7290]">
+            Live in Snap-aware Farcaster clients.{' '}
+            <Link href={`/chat-log/${encoded}`} className="underline">
+              View log
+            </Link>
+          </p>
+        </div>
+      );
+    case 'leaderboard': {
+      const bars = leaderboardData ?? [];
+      const topN = block.topN ?? 5;
+      const visible = bars.slice(0, topN);
+      return (
+        <div className="bg-[#122440] border border-[#1f3252] rounded-lg px-4 py-3 space-y-2">
+          <div className="font-bold text-sm" style={{ color: accent }}>{block.title}</div>
+          {visible.length === 0 ? (
+            <p className="text-xs text-[#8aa0bd]">No votes yet.</p>
+          ) : (
+            visible.map((bar, i) => {
+              const max = Math.max(...visible.map((b) => b.value), 1);
+              const pct = (bar.value / max) * 100;
+              return (
+                <div key={i} className="space-y-0.5">
+                  <div className="flex justify-between text-xs">
+                    <span>#{i + 1} {bar.label}</span>
+                    <span className="text-[#8aa0bd]">{bar.value}</span>
+                  </div>
+                  <div className="h-2 bg-[#1f3252] rounded">
+                    <div className="h-full rounded" style={{ width: `${pct}%`, background: accent }} />
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      );
+    }
   }
 }

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -19,7 +19,8 @@ export type BlockType =
   | 'slider'
   | 'switch'
   | 'feedback'
-  | 'chatbot';
+  | 'chatbot'
+  | 'leaderboard';
 
 // Subset of the 34 Snap icons - the most useful for blocks.
 export const ICONS = [
@@ -145,6 +146,16 @@ export interface SwitchBlock {
   defaultChecked: boolean;
 }
 
+// Live tally pulled from a referenced poll block on the same page.
+// Renders as bar_chart sorted desc, top N. v1 source = 'votes' (poll).
+export interface LeaderboardBlock {
+  type: 'leaderboard';
+  title: string;
+  source: 'votes';
+  pollBlockIdx: number;
+  topN?: number;
+}
+
 // User chats with an LLM inline. Submit logs the message + LLM reply to
 // Redis (chatlog:{snapId}) and returns a Snap with the reply + same chatbot
 // block to keep the loop going. Stateless per-turn (Snap protocol has no
@@ -194,7 +205,8 @@ type AnyBlock =
   | SliderBlock
   | SwitchBlock
   | FeedbackBlock
-  | ChatbotBlock;
+  | ChatbotBlock
+  | LeaderboardBlock;
 
 // Optional `gate` lets a block require a token-balance check before render.
 // Evaluated server-side on POST; falsy on GET (no FID), so gated blocks
@@ -384,6 +396,14 @@ export function clampBlock(block: Block): Block {
         systemPrompt: block.systemPrompt.slice(0, 2000),
         label: block.label.slice(0, LABEL_MAX),
         placeholder: block.placeholder?.slice(0, 60),
+      };
+    case 'leaderboard':
+      return {
+        ...block,
+        title: block.title.slice(0, TITLE_MAX),
+        source: 'votes',
+        pollBlockIdx: Math.max(0, Math.floor(Number(block.pollBlockIdx) || 0)),
+        topN: Math.min(Math.max(Number(block.topN) || 5, 1), 6),
       };
   }
 }

--- a/lib/blocks.ts
+++ b/lib/blocks.ts
@@ -222,6 +222,17 @@ export interface SnapPage {
   blocks: Block[];
 }
 
+/**
+ * Optional creator-coin association. When set, every page auto-prepends a
+ * swap_token button at the top so the snap doubles as a coin-buy surface.
+ */
+export interface SnapCoin {
+  /** CAIP-19 token identifier, e.g. eip155:8453/erc20:0x... */
+  caip19: string;
+  /** Display symbol, used for the button label. */
+  symbol?: string;
+}
+
 export interface SnapDoc {
   version: 1;
   title: string;
@@ -229,6 +240,8 @@ export interface SnapDoc {
   pages: SnapPage[];
   /** Snap-level effects applied on render. Currently spec supports 'confetti'. */
   confetti?: boolean;
+  /** Optional coin auto-injects a swap_token button on every page. */
+  coin?: SnapCoin;
 }
 
 export const DEFAULT_SNAP: SnapDoc = {

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -93,22 +93,26 @@ function migrateLoadedDoc(raw: unknown): SnapDoc | null {
 export async function setSnapCoin(
   id: string,
   coin: { caip19: string; symbol?: string } | null,
-): Promise<boolean> {
+): Promise<{ updated: number; missing: boolean }> {
   const c = await getClient();
-  if (!c) return false;
+  if (!c) return { updated: 0, missing: true };
+  let updated = 0;
+  let missing = true;
   for (const prefix of [KEY_PREFIX, SNAPDOC_PREFIX]) {
     const raw = await c.get(prefix + id);
     if (!raw) continue;
+    missing = false;
     try {
       const parsed = JSON.parse(raw) as Record<string, unknown>;
       if (coin) parsed.coin = coin;
       else delete parsed.coin;
       await c.set(prefix + id, JSON.stringify(parsed));
-    } catch {
-      // skip malformed
+      updated += 1;
+    } catch (err) {
+      console.error('setSnapCoin parse', prefix + id, err);
     }
   }
-  return true;
+  return { updated, missing };
 }
 
 export async function loadSnap(id: string): Promise<SnapDoc | null> {

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -172,6 +172,48 @@ export async function appendChatLog(
   await c.expire(key, 60 * 60 * 24 * 90);
 }
 
+const STATS_PREFIX = 'stats:';
+
+export interface SnapStats {
+  views: number;
+  interactions: number;
+  lastViewAt: number | null;
+  lastInteractionAt: number | null;
+}
+
+export async function bumpStat(
+  snapId: string,
+  field: 'views' | 'interactions',
+): Promise<void> {
+  const c = await getClient();
+  if (!c) return;
+  const key = STATS_PREFIX + snapId;
+  const tsField = field === 'views' ? 'lastViewAt' : 'lastInteractionAt';
+  await Promise.all([
+    c.hIncrBy(key, field, 1),
+    c.hSet(key, tsField, String(Date.now())),
+    c.expire(key, 60 * 60 * 24 * 365),
+  ]);
+}
+
+export async function getStats(snapId: string): Promise<SnapStats> {
+  const c = await getClient();
+  const empty: SnapStats = {
+    views: 0,
+    interactions: 0,
+    lastViewAt: null,
+    lastInteractionAt: null,
+  };
+  if (!c) return empty;
+  const raw = await c.hGetAll(STATS_PREFIX + snapId);
+  return {
+    views: Number(raw.views ?? 0),
+    interactions: Number(raw.interactions ?? 0),
+    lastViewAt: raw.lastViewAt ? Number(raw.lastViewAt) : null,
+    lastInteractionAt: raw.lastInteractionAt ? Number(raw.lastInteractionAt) : null,
+  };
+}
+
 export async function getChatLog(
   snapId: string,
   limit = 50,

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -71,6 +71,7 @@ function migrateLoadedDoc(raw: unknown): SnapDoc | null {
       theme: (d.theme as SnapDoc['theme']) ?? 'purple',
       pages: [{ id: 'home', blocks: d.blocks as SnapDoc['pages'][number]['blocks'] }],
       confetti: d.confetti as boolean | undefined,
+      coin: d.coin as SnapDoc['coin'],
     };
   }
 
@@ -82,10 +83,32 @@ function migrateLoadedDoc(raw: unknown): SnapDoc | null {
       theme: (d.theme as SnapDoc['theme']) ?? 'purple',
       pages: d.pages as SnapDoc['pages'],
       confetti: d.confetti as boolean | undefined,
+      coin: d.coin as SnapDoc['coin'],
     };
   }
 
   return null;
+}
+
+export async function setSnapCoin(
+  id: string,
+  coin: { caip19: string; symbol?: string } | null,
+): Promise<boolean> {
+  const c = await getClient();
+  if (!c) return false;
+  for (const prefix of [KEY_PREFIX, SNAPDOC_PREFIX]) {
+    const raw = await c.get(prefix + id);
+    if (!raw) continue;
+    try {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      if (coin) parsed.coin = coin;
+      else delete parsed.coin;
+      await c.set(prefix + id, JSON.stringify(parsed));
+    } catch {
+      // skip malformed
+    }
+  }
+  return true;
 }
 
 export async function loadSnap(id: string): Promise<SnapDoc | null> {

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -417,6 +417,26 @@ export function docToSnap(
   const allElements: Record<string, Element> = {};
   const childIds: string[] = [];
 
+  // Auto-inject coin swap button at top of every page when doc.coin is set.
+  if (doc.coin?.caip19) {
+    const symbol = doc.coin.symbol?.trim() || 'token';
+    const buyId = '_zlank_coin_buy';
+    const sepId = '_zlank_coin_sep';
+    allElements[buyId] = {
+      type: 'button',
+      props: {
+        label: `Buy $${symbol.slice(0, 24)}`,
+        variant: 'primary',
+        icon: 'coins',
+      },
+      on: {
+        press: { action: 'swap_token', params: { buyToken: doc.coin.caip19 } },
+      },
+    };
+    allElements[sepId] = { type: 'separator', props: {} };
+    childIds.push(buyId, sepId);
+  }
+
   page.blocks.forEach((block, idx) => {
     if (block.gate) {
       const result = opts.gateResults?.get(idx);

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -332,6 +332,28 @@ function blockToElements(
       ids.push(promptId, inputId, btnId);
       break;
     }
+    case 'leaderboard': {
+      // Resolved data is passed via opts.leaderboardData. If absent (no
+      // resolution available), render an empty-state text instead of a
+      // broken chart.
+      // The actual data is wired in by docToSnap below (it has access to opts).
+      // Here we just emit the placeholder; docToSnap replaces these elements.
+      const titleId = `${id}_title`;
+      const chartId = `${id}_chart`;
+      elements[titleId] = {
+        type: 'text',
+        props: { content: block.title, size: 'md', weight: 'bold' },
+      };
+      elements[chartId] = {
+        type: 'text',
+        props: {
+          content: 'No votes yet.',
+          size: 'sm',
+        },
+      };
+      ids.push(titleId, chartId);
+      break;
+    }
     case 'chatbot': {
       const titleId = `${id}_title`;
       const promptId = `${id}_prompt`;
@@ -372,6 +394,8 @@ export interface DocToSnapOpts {
   pageId?: string;
   /** Per-block-index gate results from POST handler. */
   gateResults?: Map<number, GateResult>;
+  /** Per-block-index resolved leaderboard data (label, value pairs). */
+  leaderboardData?: Map<number, Array<{ label: string; value: number }>>;
 }
 
 export function docToSnap(
@@ -409,6 +433,31 @@ export function docToSnap(
         return;
       }
     }
+
+    // Leaderboard needs async-resolved data; replace the placeholder text
+    // element with a real bar_chart when data is available.
+    if (block.type === 'leaderboard') {
+      const data = opts.leaderboardData?.get(idx);
+      const titleId = `b${idx}_title`;
+      const chartId = `b${idx}_chart`;
+      allElements[titleId] = {
+        type: 'text',
+        props: { content: block.title, size: 'md', weight: 'bold' },
+      };
+      const topN = block.topN ?? 5;
+      const bars = (data ?? []).slice(0, topN);
+      if (bars.length > 0) {
+        allElements[chartId] = { type: 'bar_chart', props: { bars } };
+      } else {
+        allElements[chartId] = {
+          type: 'text',
+          props: { content: 'No votes yet.', size: 'sm' },
+        };
+      }
+      childIds.push(titleId, chartId);
+      return;
+    }
+
     const { ids, elements } = blockToElements(block, idx, baseUrl);
     Object.assign(allElements, elements);
     childIds.push(...ids);

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -418,14 +418,16 @@ export function docToSnap(
   const childIds: string[] = [];
 
   // Auto-inject coin swap button at top of every page when doc.coin is set.
+  // Snap button label cap is 30 chars; "Buy $" prefix is 5 so symbol gets 25.
+  // swap_token uses `buyToken` (target), no `sellToken` (FC client picks).
   if (doc.coin?.caip19) {
-    const symbol = doc.coin.symbol?.trim() || 'token';
+    const symbol = (doc.coin.symbol?.trim() || 'token').slice(0, 12);
     const buyId = '_zlank_coin_buy';
     const sepId = '_zlank_coin_sep';
     allElements[buyId] = {
       type: 'button',
       props: {
-        label: `Buy $${symbol.slice(0, 24)}`,
+        label: `Buy $${symbol}`,
         variant: 'primary',
         icon: 'coins',
       },

--- a/lib/validate-snap.ts
+++ b/lib/validate-snap.ts
@@ -75,6 +75,12 @@ function lintBlock(block: Block, idx: number): string[] {
         issues.push(`${here}: chart needs at least 1 bar`);
       }
       break;
+    case 'leaderboard':
+      if (!block.title?.trim()) issues.push(`${here}: leaderboard title is empty`);
+      if (!Number.isFinite(block.pollBlockIdx) || block.pollBlockIdx < 0) {
+        issues.push(`${here}: leaderboard pollBlockIdx must be >= 0`);
+      }
+      break;
   }
   return issues;
 }

--- a/lib/validate-snap.ts
+++ b/lib/validate-snap.ts
@@ -5,7 +5,7 @@ import type { SnapDoc, Block } from './blocks';
 
 // Source-doc lint - catches user input mistakes that snap-spec would silently
 // paper over (e.g. empty text content gets padded with a space at render).
-function lintBlock(block: Block, idx: number): string[] {
+function lintBlock(block: Block, idx: number, pageBlocks: Block[]): string[] {
   const issues: string[] = [];
   const here = `block ${idx} (${block.type})`;
   switch (block.type) {
@@ -75,12 +75,22 @@ function lintBlock(block: Block, idx: number): string[] {
         issues.push(`${here}: chart needs at least 1 bar`);
       }
       break;
-    case 'leaderboard':
+    case 'leaderboard': {
       if (!block.title?.trim()) issues.push(`${here}: leaderboard title is empty`);
-      if (!Number.isFinite(block.pollBlockIdx) || block.pollBlockIdx < 0) {
+      const pIdx = block.pollBlockIdx;
+      if (!Number.isFinite(pIdx) || pIdx < 0) {
         issues.push(`${here}: leaderboard pollBlockIdx must be >= 0`);
+      } else if (pIdx >= pageBlocks.length) {
+        issues.push(
+          `${here}: leaderboard pollBlockIdx ${pIdx} out of range (page has ${pageBlocks.length} blocks)`,
+        );
+      } else if (pageBlocks[pIdx]?.type !== 'poll') {
+        issues.push(
+          `${here}: leaderboard pollBlockIdx ${pIdx} points at a ${pageBlocks[pIdx]?.type ?? '?'} block, not a poll`,
+        );
       }
       break;
+    }
   }
   return issues;
 }
@@ -118,7 +128,7 @@ export function validateDoc(doc: SnapDoc, baseUrl = 'https://zlank.online/api/sn
     // Source-doc lint first (catches user input mistakes regardless of how
     // snap-spec.ts handles them at render time).
     page.blocks.forEach((block, idx) => {
-      issues.push(...lintBlock(block, idx));
+      issues.push(...lintBlock(block, idx, page.blocks));
     });
 
     let snap: unknown;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@farcaster/snap": "^2.1.1",
         "@farcaster/snap-hono": "^2.0.5",
         "@hono/node-server": "^2.0.0",
+        "@vercel/blob": "^2.3.3",
         "hono": "^4.12.15",
         "nanoid": "^5.1.9",
         "next": "16.2.4",
@@ -1502,6 +1503,22 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.3.tgz",
+      "integrity": "sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/abitype": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
@@ -1533,6 +1550,15 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/base-x": {
@@ -1901,6 +1927,35 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
@@ -2610,6 +2665,15 @@
         "node": ">= 18.19.0"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rpc-websockets": {
       "version": "9.3.8",
       "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.8.tgz",
@@ -2883,6 +2947,18 @@
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
       "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -2912,6 +2988,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@farcaster/snap-hono": "^2.0.5",
         "@hono/node-server": "^2.0.0",
         "@vercel/blob": "^2.3.3",
+        "@zoralabs/coins-sdk": "^0.6.0",
         "hono": "^4.12.15",
         "nanoid": "^5.1.9",
         "next": "16.2.4",
@@ -171,6 +172,16 @@
       },
       "peerDependencies": {
         "hono": ">=4.0.0"
+      }
+    },
+    "node_modules/@hey-api/client-fetch": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/client-fetch/-/client-fetch-0.8.4.tgz",
+      "integrity": "sha512-SWtUjVEFIUdiJGR2NiuF0njsSrSdTe7WHWkp3BLH3DEl2bRhiflOnBo29NSDdrY90hjtTQiTQkBxUgGOF29Xzg==",
+      "deprecated": "Starting with v0.73.0, this package is bundled directly inside @hey-api/openapi-ts.",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1518,6 +1529,29 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@zoralabs/coins-sdk": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@zoralabs/coins-sdk/-/coins-sdk-0.6.0.tgz",
+      "integrity": "sha512-utDp5giITAOybvQme15lVaFiBEfKS7dxNyRWP9BpvZ4yNiAI5/OD5eJqfABkwWdti1KRjpa25xdc8LMxXuyLlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hey-api/client-fetch": "^0.8.3",
+        "@zoralabs/protocol-deployments": "^0.7.5"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "abitype": "^1.0.8",
+        "viem": "2.22.12"
+      }
+    },
+    "node_modules/@zoralabs/protocol-deployments": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@zoralabs/protocol-deployments/-/protocol-deployments-0.7.5.tgz",
+      "integrity": "sha512-LtvwBipo0Rpz5OefWfaoxpSnfxFIlTSMYcExmHYSxU+XS9REUS3cjvAH2YxQjhlvmHVMUlJ3bcDAbchnlY+ucQ==",
+      "license": "MIT"
     },
     "node_modules/abitype": {
       "version": "1.2.4",
@@ -2981,6 +3015,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -3013,21 +3048,6 @@
       "dependencies": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
-      }
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@farcaster/snap": "^2.1.1",
     "@farcaster/snap-hono": "^2.0.5",
     "@hono/node-server": "^2.0.0",
+    "@vercel/blob": "^2.3.3",
     "hono": "^4.12.15",
     "nanoid": "^5.1.9",
     "next": "16.2.4",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@farcaster/snap-hono": "^2.0.5",
     "@hono/node-server": "^2.0.0",
     "@vercel/blob": "^2.3.3",
+    "@zoralabs/coins-sdk": "^0.6.0",
     "hono": "^4.12.15",
     "nanoid": "^5.1.9",
     "next": "16.2.4",


### PR DESCRIPTION
SnapDoc.coin = {caip19, symbol?}. When set, every page auto-prepends Buy \$X button using snap swap_token action. Builder UI + POST /api/snaps/{id}/coin endpoint. Defers wallet-side coin creation. Stacks on #22.