### PR TITLE
fix(deps): drop unused @zoralabs/coins-sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@farcaster/snap-hono": "^2.0.5",
         "@hono/node-server": "^2.0.0",
         "@vercel/blob": "^2.3.3",
-        "@zoralabs/coins-sdk": "^0.6.0",
         "hono": "^4.12.15",
         "nanoid": "^5.1.9",
         "next": "16.2.4",
@@ -172,16 +171,6 @@
       },
       "peerDependencies": {
         "hono": ">=4.0.0"
-      }
-    },
-    "node_modules/@hey-api/client-fetch": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@hey-api/client-fetch/-/client-fetch-0.8.4.tgz",
-      "integrity": "sha512-SWtUjVEFIUdiJGR2NiuF0njsSrSdTe7WHWkp3BLH3DEl2bRhiflOnBo29NSDdrY90hjtTQiTQkBxUgGOF29Xzg==",
-      "deprecated": "Starting with v0.73.0, this package is bundled directly inside @hey-api/openapi-ts.",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1529,29 +1518,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/@zoralabs/coins-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@zoralabs/coins-sdk/-/coins-sdk-0.6.0.tgz",
-      "integrity": "sha512-utDp5giITAOybvQme15lVaFiBEfKS7dxNyRWP9BpvZ4yNiAI5/OD5eJqfABkwWdti1KRjpa25xdc8LMxXuyLlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@hey-api/client-fetch": "^0.8.3",
-        "@zoralabs/protocol-deployments": "^0.7.5"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "abitype": "^1.0.8",
-        "viem": "2.22.12"
-      }
-    },
-    "node_modules/@zoralabs/protocol-deployments": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@zoralabs/protocol-deployments/-/protocol-deployments-0.7.5.tgz",
-      "integrity": "sha512-LtvwBipo0Rpz5OefWfaoxpSnfxFIlTSMYcExmHYSxU+XS9REUS3cjvAH2YxQjhlvmHVMUlJ3bcDAbchnlY+ucQ==",
-      "license": "MIT"
     },
     "node_modules/abitype": {
       "version": "1.2.4",
@@ -3015,7 +2981,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@farcaster/snap-hono": "^2.0.5",
     "@hono/node-server": "^2.0.0",
     "@vercel/blob": "^2.3.3",
-    "@zoralabs/coins-sdk": "^0.6.0",
     "hono": "^4.12.15",
     "nanoid": "^5.1.9",
     "next": "16.2.4",


### PR DESCRIPTION
Blocks Vercel install via viem peer conflict (sdk pins 2.22.12, project uses 2.48). Never imported - was added in PR #31 for a deferred wallet-launch flow. Re-add via .npmrc legacy-peer-deps when wallet-launch ships.