### PR TITLE
feat(v1): adopt Snap best practices from doc 534

### DIFF
--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -44,6 +44,25 @@ async function getEncoded(ctx: { params: Promise<{ encoded: string }> }): Promis
   return encoded;
 }
 
+/**
+ * Validate ?page= against the doc's known page IDs. Unknown pages fall through
+ * to the doc's first page so a malformed URL never renders a blank Snap.
+ * Per official examples (element-showcase, snap-catalog) - "view guard" pattern.
+ */
+function resolvePageId(doc: SnapDoc, requested: string | undefined): string | undefined {
+  if (!requested) return undefined;
+  const known = doc.pages.some((p) => p.id === requested);
+  return known ? requested : undefined;
+}
+
+/**
+ * In production we verify the JFS signature on every POST so input + FID are
+ * trustworthy. In dev / preview / emulator we keep the permissive parse so
+ * curl + the snap-emulator continue to work without signing.
+ */
+const VERIFY_JFS_IN_PROD = process.env.NODE_ENV === 'production' &&
+  process.env.ZLANK_VERIFY_JFS !== 'false';
+
 const CORS_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
@@ -190,7 +209,8 @@ export async function GET(
   const encoded = await getEncoded(ctx);
   const doc = (await resolveSnap(encoded)) ?? FALLBACK_DOC;
   const origin = getOrigin(req);
-  const pageId = new URL(req.url).searchParams.get('page') ?? undefined;
+  const requestedPage = new URL(req.url).searchParams.get('page') ?? undefined;
+  const pageId = resolvePageId(doc, requestedPage);
 
   // Content negotiation: Snap-aware clients ask for the snap media type.
   const accept = req.headers.get('accept') ?? '';
@@ -213,15 +233,18 @@ export async function POST(
   const encoded = await getEncoded(ctx);
   const doc = (await resolveSnap(encoded)) ?? FALLBACK_DOC;
   const origin = getOrigin(req);
-  const pageId = new URL(req.url).searchParams.get('page') ?? undefined;
+  const requestedPage = new URL(req.url).searchParams.get('page') ?? undefined;
+  const pageId = resolvePageId(doc, requestedPage);
 
   // Parse JFS POST body for inputs + the viewer's FID (used for gate eval).
+  // Production: verify signature so inputs/fid are trustworthy.
+  // Dev / preview / emulator: skip verification so curl + snap-emulator work.
   let inputs: Record<string, unknown> = {};
   let fid: number | undefined;
   try {
     const parsed = await parseRequest(req.clone(), {
-      skipJFSVerification: true,
-      maxSkewSeconds: 60 * 60 * 24 * 365,
+      skipJFSVerification: !VERIFY_JFS_IN_PROD,
+      maxSkewSeconds: VERIFY_JFS_IN_PROD ? 60 * 5 : 60 * 60 * 24 * 365,
     });
     if (parsed.success && parsed.action.type === 'post') {
       inputs = parsed.action.inputs ?? {};
@@ -230,7 +253,10 @@ export async function POST(
   } catch {
     // try fallback raw parse
   }
-  if (Object.keys(inputs).length === 0 || fid === undefined) {
+  // Raw fallback: base64-decode the payload field directly. Only safe in dev /
+  // emulator because it skips the JFS signature; in prod we trust parseRequest
+  // above + would log unsigned attempts.
+  if ((Object.keys(inputs).length === 0 || fid === undefined) && !VERIFY_JFS_IN_PROD) {
     try {
       const body = (await req.clone().json()) as {
         payload?: string;

--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -510,7 +510,7 @@ export function docToSnap(
   };
 
   const out: Record<string, unknown> = {
-    version: '1.0',
+    version: '2.0',
     theme: { accent: doc.theme },
     ui: {
       root: 'page',

--- a/lib/templates.ts
+++ b/lib/templates.ts
@@ -394,6 +394,96 @@ export const TEMPLATES: TemplateMeta[] = [
       ],
     },
   },
+  {
+    id: 'multi-step-form',
+    name: 'Multi-step Form',
+    description: 'Three-page intake walkthrough modeled on the official snap-catalog example.',
+    doc: {
+      version: 1,
+      title: 'Tell us about your build',
+      theme: 'blue',
+      pages: [
+        {
+          id: 'home',
+          blocks: [
+            {
+              type: 'header',
+              title: 'Step 1 of 3',
+              subtitle: 'What are you working on?',
+              badgeText: '1/3',
+              badgeColor: 'blue',
+            },
+            {
+              type: 'feedback',
+              label: 'Continue',
+              prompt: 'Pitch your idea in one line',
+              mention: 'zaal',
+              prefix: 'multi-step intake:',
+            },
+            {
+              type: 'navigate',
+              label: 'Next: pick a category',
+              pageId: 'category',
+              icon: 'chevron-right',
+              variant: 'primary',
+            },
+          ],
+        },
+        {
+          id: 'category',
+          blocks: [
+            {
+              type: 'header',
+              title: 'Step 2 of 3',
+              subtitle: 'Pick the closest category',
+              badgeText: '2/3',
+              badgeColor: 'blue',
+            },
+            {
+              type: 'poll',
+              question: 'Category',
+              options: ['Music', 'Tooling', 'Community', 'Other'],
+            },
+            {
+              type: 'navigate',
+              label: 'Next: how soon to ship',
+              pageId: 'timeline',
+              icon: 'chevron-right',
+              variant: 'primary',
+            },
+          ],
+        },
+        {
+          id: 'timeline',
+          blocks: [
+            {
+              type: 'header',
+              title: 'Step 3 of 3',
+              subtitle: 'Timeline',
+              badgeText: '3/3',
+              badgeColor: 'blue',
+            },
+            {
+              type: 'slider',
+              label: 'Days to ship',
+              min: 1,
+              max: 30,
+              defaultValue: 7,
+            },
+            {
+              type: 'switch',
+              label: 'Open-source by default',
+              defaultChecked: true,
+            },
+            {
+              type: 'text',
+              content: 'Thanks. Each step logs separately - check the chat log for the full thread.',
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];
 
 export function getTemplateById(id: string): TemplateMeta | undefined {


### PR DESCRIPTION
## Summary
Promotes Zlank to v1 by adopting the 4 code recommendations from research doc 534 (research/farcaster/534-snap-best-practices-from-the-wild). The 5th recommendation (set apex as Vercel primary) is a 1-min Vercel dashboard click - not in this PR.

## What's in
1. **Snap response v2.0** - bumped from v1.0 in lib/snap-spec.ts. v1 lives only in the deprecated version-test example.
2. **JFS signature verification gated on NODE_ENV** - prod verifies (5-min skew), dev / preview / emulator skips (1-year skew, raw base64 fallback). Override in prod via ZLANK_VERIFY_JFS=false. Closes the gap from farcasterxyz/snap#137.
3. **View-guard for ?page=** - unknown IDs fall through to first page instead of rendering blank.
4. **Multi-step Form template** - 3 pages w/ badges, navigate, feedback, slider, switch. 11th template, modeled on official snap-catalog example.

## Manual follow-up (after merge)
Vercel dashboard -> zlank -> Settings -> Domains -> set zlank.online as Primary. Kills the 307 -> www CORS gotcha that breaks the Snap emulator.

## Test plan
- [ ] Smoke all existing demo Snaps in emulator (v8-myn, qQE7TW, ngUIPo, kZUJVv, zn_uYK) - still render correctly with v2.0
- [ ] /builder -> add a Multi-step Form template -> deploy -> walk through 3 pages
- [ ] curl POST a snap with a bogus payload -> in prod returns same as no-input (gated by JFS verify); in dev still works
- [ ] curl GET ?page=garbage -> renders home page, not blank