### PR TITLE
feat(polish): chatbot reply hygiene + drag-reorder + import-from-snap

### DIFF
--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -37,6 +37,17 @@ const BLOCK_OPTIONS: { type: BlockType; label: string; icon: string }[] = [
   { type: 'divider', label: 'Divider', icon: '-' },
 ];
 
+// Pure helper - move blocks[from] to position `to`, preserving everything else.
+function newPages_reorderHelper<T>(arr: readonly T[], from: number, to: number): T[] {
+  if (from === to || from < 0 || from >= arr.length || to < 0 || to >= arr.length) {
+    return [...arr];
+  }
+  const next = [...arr];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}
+
 function newBlock(type: BlockType, availablePageIds: string[] = []): Block {
   switch (type) {
     case 'header':
@@ -226,6 +237,47 @@ export default function Builder() {
       newPages[pageIdx] = { ...newPages[pageIdx], blocks: nextBlocks };
       return { ...d, pages: newPages };
     });
+  }
+
+  function reorderBlock(from: number, to: number) {
+    setDoc((d) => {
+      const pageIdx = d.pages.findIndex((p) => p.id === currentPageId);
+      if (pageIdx === -1) return d;
+      const blocks = newPages_reorderHelper(d.pages[pageIdx].blocks, from, to);
+      const newPages = [...d.pages];
+      newPages[pageIdx] = { ...newPages[pageIdx], blocks };
+      return { ...d, pages: newPages };
+    });
+  }
+
+  async function importFromSnap(otherSnapId: string) {
+    const id = otherSnapId.trim();
+    if (!id) return;
+    try {
+      const res = await fetch(`/api/snaps/${encodeURIComponent(id)}/doc`);
+      if (!res.ok) {
+        alert(`Snap not found: ${id}`);
+        return;
+      }
+      const other = (await res.json()) as SnapDoc;
+      const importedBlocks = other.pages[0]?.blocks ?? [];
+      if (importedBlocks.length === 0) {
+        alert('That snap has no blocks on page 1.');
+        return;
+      }
+      setDoc((d) => {
+        const pageIdx = d.pages.findIndex((p) => p.id === currentPageId);
+        if (pageIdx === -1) return d;
+        const newPages = [...d.pages];
+        newPages[pageIdx] = {
+          ...newPages[pageIdx],
+          blocks: [...newPages[pageIdx].blocks, ...importedBlocks],
+        };
+        return { ...d, pages: newPages };
+      });
+    } catch (err: unknown) {
+      alert(err instanceof Error ? err.message : 'Import failed');
+    }
   }
 
   function addPage() {
@@ -488,9 +540,15 @@ export default function Builder() {
                 onChange={(patch) => updateBlock(idx, patch)}
                 onRemove={() => removeBlock(idx)}
                 onMove={(dir) => moveBlock(idx, dir)}
+                onReorder={reorderBlock}
                 allPageIds={doc.pages.map((p) => p.id)}
               />
             ))}
+          </div>
+
+          <div className="border-t border-[#1f3252] pt-3 space-y-2">
+            <h3 className="text-xs text-[#8aa0bd] uppercase tracking-wide">Import</h3>
+            <ImportFromSnap onImport={importFromSnap} />
           </div>
 
           <div className="border-t border-[#1f3252] pt-3 space-y-2">
@@ -548,6 +606,7 @@ function BlockEditor({
   onChange,
   onRemove,
   onMove,
+  onReorder,
   allPageIds = [],
 }: {
   block: Block;
@@ -556,12 +615,38 @@ function BlockEditor({
   onChange: (patch: Partial<Block>) => void;
   onRemove: () => void;
   onMove: (dir: -1 | 1) => void;
+  onReorder?: (from: number, to: number) => void;
   allPageIds?: string[];
 }) {
+  const [dragOver, setDragOver] = useState(false);
   return (
-    <div className="bg-[#122440] border border-[#1f3252] rounded p-3 space-y-2">
+    <div
+      draggable={!!onReorder}
+      onDragStart={(e) => {
+        e.dataTransfer.setData('text/plain', String(idx));
+        e.dataTransfer.effectAllowed = 'move';
+      }}
+      onDragOver={(e) => {
+        if (!onReorder) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        setDragOver(true);
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={(e) => {
+        if (!onReorder) return;
+        e.preventDefault();
+        setDragOver(false);
+        const from = Number(e.dataTransfer.getData('text/plain'));
+        if (Number.isFinite(from) && from !== idx) onReorder(from, idx);
+      }}
+      className={`bg-[#122440] border rounded p-3 space-y-2 ${dragOver ? 'border-[#f5a623]' : 'border-[#1f3252]'}`}
+    >
       <div className="flex items-center justify-between gap-2">
-        <span className="text-xs text-[#f5a623] uppercase">{block.type}</span>
+        <span className="text-xs text-[#f5a623] uppercase flex items-center gap-1">
+          <span className="cursor-grab text-[#5e7290]" title="Drag to reorder">::</span>
+          {block.type}
+        </span>
         <div className="flex gap-1 text-xs">
           <button onClick={() => onMove(-1)} disabled={idx === 0} className="px-2 py-0.5 hover:bg-[#1f3252] rounded disabled:opacity-30">
             up
@@ -960,6 +1045,42 @@ function BlockEditor({
       {block.type === 'divider' && <p className="text-xs text-[#8aa0bd]">Visual separator. No fields.</p>}
 
       <GateEditor block={block} onChange={onChange} />
+    </div>
+  );
+}
+
+function ImportFromSnap({ onImport }: { onImport: (id: string) => void | Promise<void> }) {
+  const [val, setVal] = useState('');
+  const [busy, setBusy] = useState(false);
+  async function go() {
+    const id = val.trim().split('/').pop()?.trim();
+    if (!id) return;
+    setBusy(true);
+    try {
+      await onImport(id);
+      setVal('');
+    } finally {
+      setBusy(false);
+    }
+  }
+  return (
+    <div className="flex gap-2">
+      <input
+        value={val}
+        onChange={(e) => setVal(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') go();
+        }}
+        placeholder="Snap id or URL (e.g. v8-myn)"
+        className="flex-1 bg-[#122440] border border-[#1f3252] rounded px-2 py-1 text-sm"
+      />
+      <button
+        onClick={go}
+        disabled={busy || !val.trim()}
+        className="px-3 py-1 bg-[#f5a623] text-[#0a1628] rounded text-xs font-bold disabled:opacity-40"
+      >
+        {busy ? '...' : 'Import'}
+      </button>
     </div>
   );
 }

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -6,6 +6,33 @@ interface ChatMessage {
   content: string;
 }
 
+// Always wrap the caller's system prompt with this context. Stops the model
+// from inventing unrelated context (e.g. "deepfake app from China") when the
+// user's input is short and ambiguous.
+const SYSTEM_PREFIX = `You are a chatbot embedded inside a Zlank Snap on Farcaster.
+Zlank is a no-code Farcaster Snap builder at zlank.online. The user is a
+Farcaster builder talking about something they're working on or interested in.
+Reply in plain text only - no markdown, no code blocks, no <think> tags.
+Keep replies to 1-2 sentences max. Never invent context the user didn't give you.`;
+
+// Strip thinking-mode artifacts that some models (Minimax M2.7, Claude
+// extended-thinking, DeepSeek R1) leak into output. Also collapse markdown
+// fences and excess whitespace because Snap text blocks render plain text.
+function sanitizeReply(raw: string): string {
+  let out = raw;
+  // Drop entire <think>...</think> blocks, including unclosed ones at the start.
+  out = out.replace(/<think[\s\S]*?<\/think>/gi, '');
+  out = out.replace(/^[\s\S]*?<\/think>/i, '');
+  // Drop other reasoning-tag variants some models emit.
+  out = out.replace(/<reasoning[\s\S]*?<\/reasoning>/gi, '');
+  out = out.replace(/<thinking[\s\S]*?<\/thinking>/gi, '');
+  // Drop fenced code blocks - Snap text doesn't render them.
+  out = out.replace(/```[\s\S]*?```/g, '');
+  // Collapse runs of whitespace/newlines to a single space, then trim.
+  out = out.replace(/\s+/g, ' ').trim();
+  return out;
+}
+
 const MINIMAX_KEY = process.env.MINIMAX_API_KEY;
 const MINIMAX_URL =
   process.env.MINIMAX_API_URL || 'https://api.minimax.io/v1/chat/completions';
@@ -14,12 +41,20 @@ const MINIMAX_MODEL = process.env.MINIMAX_MODEL || 'MiniMax-M2.7';
 const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY;
 const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL || 'claude-haiku-4-5-20251001';
 
+function withZlankContext(messages: ChatMessage[]): ChatMessage[] {
+  const callerSystem = messages.find((m) => m.role === 'system')?.content ?? '';
+  const wrappedSystem = `${SYSTEM_PREFIX}\n\n${callerSystem}`.trim();
+  const rest = messages.filter((m) => m.role !== 'system');
+  return [{ role: 'system', content: wrappedSystem }, ...rest];
+}
+
 export async function chat(
   messages: ChatMessage[],
   opts: { maxTokens?: number; timeoutMs?: number } = {},
 ): Promise<string | null> {
   const maxTokens = opts.maxTokens ?? 200;
   const timeoutMs = opts.timeoutMs ?? 8000;
+  const wrapped = withZlankContext(messages);
 
   if (MINIMAX_KEY) {
     try {
@@ -31,7 +66,7 @@ export async function chat(
           Authorization: `Bearer ${MINIMAX_KEY}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ model: MINIMAX_MODEL, messages, max_tokens: maxTokens }),
+        body: JSON.stringify({ model: MINIMAX_MODEL, messages: wrapped, max_tokens: maxTokens }),
         signal: ctrl.signal,
       });
       clearTimeout(timer);
@@ -39,8 +74,11 @@ export async function chat(
         const data = (await res.json()) as {
           choices?: Array<{ message?: { content?: string } }>;
         };
-        const text = data.choices?.[0]?.message?.content?.trim();
-        if (text) return text;
+        const raw = data.choices?.[0]?.message?.content;
+        if (raw) {
+          const cleaned = sanitizeReply(raw);
+          if (cleaned) return cleaned;
+        }
       }
     } catch {
       // fall through to Anthropic
@@ -51,8 +89,8 @@ export async function chat(
     try {
       const ctrl = new AbortController();
       const timer = setTimeout(() => ctrl.abort(), timeoutMs);
-      const sys = messages.find((m) => m.role === 'system')?.content;
-      const conv = messages.filter((m) => m.role !== 'system');
+      const sys = wrapped.find((m) => m.role === 'system')?.content;
+      const conv = wrapped.filter((m) => m.role !== 'system');
       const res = await fetch('https://api.anthropic.com/v1/messages', {
         method: 'POST',
         headers: {
@@ -73,8 +111,11 @@ export async function chat(
         const data = (await res.json()) as {
           content?: Array<{ type: string; text?: string }>;
         };
-        const text = data.content?.find((b) => b.type === 'text')?.text?.trim();
-        if (text) return text;
+        const raw = data.content?.find((b) => b.type === 'text')?.text;
+        if (raw) {
+          const cleaned = sanitizeReply(raw);
+          if (cleaned) return cleaned;
+        }
       }
     } catch {
       // give up
@@ -83,3 +124,6 @@ export async function chat(
 
   return null;
 }
+
+// Exported for unit tests.
+export { sanitizeReply, withZlankContext };


### PR DESCRIPTION
## Summary
Closes the biggest UX dent (chatbot leaking <think> blocks + hallucinating context) plus 2 builder QoL features.

## What's in
1. **sanitizeReply()** in lib/llm.ts strips <think>, <thinking>, <reasoning> blocks + fenced code blocks + collapses whitespace. Catches the artifacts Minimax M2.7 / Claude extended-thinking / DeepSeek R1 leak.
2. **withZlankContext()** prepends a Zlank/Farcaster grounding system prompt. Fixes the "user said ZAO -> model invents deepfake-app-from-China" hallucination by anchoring context first.
3. **Drag-to-reorder** blocks in /builder. HTML5 draggable, drop target shows gold border. Existing up/dn buttons still work.
4. **Import from snap** field at bottom of the Blocks panel. Paste any snap id/URL, hit Import, page-1 blocks append to your current page.

## Test plan
- [ ] Open https://www.zlank.online/api/snap/v8-myn in emulator, type "test", Submit -> reply is plain text, no <think> block, no markdown
- [ ] Type a vague short message -> reply doesn't invent unrelated context
- [ ] /builder -> drag a block onto another -> order changes
- [ ] /builder -> Import from snap "v8-myn" -> chatbot block appears at end of current page