### PR TITLE
fix(snap-spec): auto-chunk root children into nested stacks (4 broken templates)

### DIFF
--- a/lib/snap-spec.ts
+++ b/lib/snap-spec.ts
@@ -503,10 +503,21 @@ export function docToSnap(
   };
   childIds.push('_zlank_sep', '_zlank_footer');
 
+  // Snap v2 limit: root has 7 direct children max, each nested stack 6 max,
+  // up to 4 levels deep. We hit this when interactive blocks expand into 4+
+  // sub-elements each. Auto-group into balanced sub-stacks so any number of
+  // blocks (within the 64 total) renders.
+  const ROOT_MAX = 7;
+  const NEST_MAX = 6;
+  const rootChildren = chunkIntoStacks(childIds, allElements, {
+    rootMax: ROOT_MAX,
+    nestMax: NEST_MAX,
+  });
+
   allElements['page'] = {
     type: 'stack',
     props: { direction: 'vertical', gap: 'md' },
-    children: childIds,
+    children: rootChildren,
   };
 
   const out: Record<string, unknown> = {
@@ -523,4 +534,44 @@ export function docToSnap(
   }
 
   return out;
+}
+
+/**
+ * Group child element IDs into nested stacks so the root has at most rootMax
+ * direct children. Snap v2 catalog limits: root 7, nested 6, max depth 4.
+ * Adds the new sub-stack elements directly to `elements` (in-place) and
+ * returns the new root children list.
+ */
+function chunkIntoStacks(
+  ids: string[],
+  elements: Record<string, Element>,
+  caps: { rootMax: number; nestMax: number },
+  depth = 0,
+  prefix = '_zlank_grp',
+): string[] {
+  if (ids.length <= caps.rootMax) return ids;
+  if (depth >= 3) {
+    // Hit nesting cap; return as-is and let the validator surface it.
+    return ids;
+  }
+  // Aim for roughly equal chunks that respect nestMax.
+  const chunkSize = Math.min(
+    caps.nestMax,
+    Math.ceil(ids.length / caps.rootMax),
+  );
+  const groups: string[][] = [];
+  for (let i = 0; i < ids.length; i += chunkSize) {
+    groups.push(ids.slice(i, i + chunkSize));
+  }
+  const groupIds: string[] = groups.map((group, gIdx) => {
+    const groupId = `${prefix}_${depth}_${gIdx}`;
+    elements[groupId] = {
+      type: 'stack',
+      props: { direction: 'vertical', gap: 'md' },
+      children: group,
+    };
+    return groupId;
+  });
+  // If grouping still exceeds rootMax, recurse one level deeper.
+  return chunkIntoStacks(groupIds, elements, caps, depth + 1, `${prefix}_n`);
 }

--- a/scripts/audit-templates.ts
+++ b/scripts/audit-templates.ts
@@ -1,0 +1,46 @@
+// Run with: npx tsx scripts/audit-templates.ts
+// Validates every template via the same validateDoc() the save endpoint uses,
+// then renders + checks output for every page.
+
+import { TEMPLATES } from '../lib/templates';
+import { validateDoc } from '../lib/validate-snap';
+import { docToSnap } from '../lib/snap-spec';
+
+let pass = 0;
+let fail = 0;
+
+for (const t of TEMPLATES) {
+  const result = validateDoc(t.doc);
+  if (result.ok) {
+    // Also verify each page renders without throwing.
+    let renderOk = true;
+    for (const p of t.doc.pages) {
+      try {
+        const snap = docToSnap(t.doc, 'https://zlank.online/api/snap/test', { pageId: p.id });
+        const elementCount = Object.keys(
+          (snap as { ui: { elements: Record<string, unknown> } }).ui.elements,
+        ).length;
+        if (elementCount === 0) {
+          console.log(`[FAIL] ${t.id} - page ${p.id} rendered 0 elements`);
+          renderOk = false;
+        }
+      } catch (err) {
+        console.log(`[FAIL] ${t.id} - page ${p.id} threw:`, err instanceof Error ? err.message : err);
+        renderOk = false;
+      }
+    }
+    if (renderOk) {
+      console.log(`[OK]   ${t.id} (${t.doc.pages.length} page${t.doc.pages.length > 1 ? 's' : ''}, ${t.doc.pages.reduce((s, p) => s + p.blocks.length, 0)} blocks)`);
+      pass += 1;
+    } else {
+      fail += 1;
+    }
+  } else {
+    console.log(`[FAIL] ${t.id}:`);
+    for (const issue of result.errors) console.log(`         - ${issue}`);
+    fail += 1;
+  }
+}
+
+console.log(`\n${pass}/${pass + fail} templates pass.`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
Audited all 11 templates with new scripts/audit-templates.ts. **4 were broken** by the v2 7-direct-children root cap: member-welcome, idea-box, bug-report, multi-step-form (timeline page).

Root cause: every block emitted straight under root page stack. Interactive blocks like chatbot/feedback fan out into 4-5 sub-elements each, blowing the cap fast.

## Fix
chunkIntoStacks() packs root children into balanced nested sub-stacks (max 6 per level, recurses to depth 4). Snap v2 envelope happy.

## Audit results
- before: 7/11 pass
- after: 11/11 pass

## Test plan
- [ ] /templates -> click each of the 11 cards -> deploys w/o validator error
- [ ] Each deployed snap renders in emulator
- [ ] Existing demo snaps (v8-myn, qQE7TW, ngUIPo, kZUJVv, zn_uYK) still render