### PR TITLE
feat(polish-t2): rate limits + vote dedupe + chat cooldown + auto-save + cast button

### DIFF
--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { parseRequest } from '@farcaster/snap/server';
 import { resolveSnap } from '@/lib/resolve-snap';
 import { docToSnap } from '@/lib/snap-spec';
-import { recordVote, appendChatLog, bumpStat, getVotes } from '@/lib/kv';
+import { recordVote, appendChatLog, bumpStat, getVotes, claimVote, claimChatTurn } from '@/lib/kv';
 import { evaluateGates, isGateRule, type GateResult } from '@/lib/gates';
 import { chat as llmChat } from '@/lib/llm';
 import type { SnapDoc, Block, ChartBar } from '@/lib/blocks';
@@ -294,9 +294,16 @@ export async function POST(
     const blockIdx = Number(voteKey.replace('vote_', ''));
     const optionRaw = String(voteValue ?? '').trim();
     if (optionRaw) {
-      const tallies = await recordVote(encoded, blockIdx, optionRaw);
+      // One vote per FID per poll. Anonymous votes (no FID) always count.
+      const firstVote = await claimVote(encoded, blockIdx, fid);
+      let tallies: Record<string, number>;
+      if (firstVote) {
+        tallies = await recordVote(encoded, blockIdx, optionRaw);
+      } else {
+        tallies = await getVotes(encoded, blockIdx);
+      }
       return snapJsonResponse(
-        buildResultsDoc(doc, blockIdx, tallies, optionRaw),
+        buildResultsDoc(doc, blockIdx, tallies, optionRaw, !firstVote),
         origin,
         encoded,
         pageId,
@@ -313,6 +320,16 @@ export async function POST(
       const targetPage = doc.pages.find((p) => p.id === (pageId || doc.pages[0]?.id));
       const block = targetPage?.blocks[blockIdx];
       if (block?.type === 'chatbot') {
+        // Per-FID 10s cooldown so a single user can't flood the LLM + log.
+        const allowed = await claimChatTurn(encoded, fid, 10);
+        if (!allowed) {
+          return snapJsonResponse(
+            buildChatCooldownDoc(doc, block),
+            origin,
+            encoded,
+            pageId,
+          );
+        }
         const reply = await llmChat(
           [
             { role: 'system', content: block.systemPrompt },
@@ -368,24 +385,43 @@ export async function POST(
 
 function buildResultsDoc(
   doc: SnapDoc,
-  blockIdx: number,
+  _blockIdx: number,
   tallies: Record<string, number>,
   votedFor: string,
+  alreadyVoted = false,
 ): SnapDoc {
   const bars: ChartBar[] = Object.entries(tallies)
     .sort(([, a], [, b]) => b - a)
     .map(([label, value]) => ({ label, value }));
   const total = bars.reduce((s, b) => s + b.value, 0);
+  const headerTitle = alreadyVoted ? 'Already voted' : 'Vote recorded';
+  const headerSubtitle = alreadyVoted
+    ? `Your earlier pick stands. Live tally below.`
+    : `You picked: ${votedFor}`;
   const newBlocks: Block[] = [
-    { type: 'header', title: 'Vote recorded', subtitle: `You picked: ${votedFor}` },
+    { type: 'header', title: headerTitle, subtitle: headerSubtitle },
     { type: 'chart', title: `Live results (${total} votes)`, bars },
     { type: 'divider' },
-    { type: 'text', content: 'Tap the original cast to vote again or share.' },
+    { type: 'text', content: 'Tap the original cast to share.' },
   ];
   return {
     ...doc,
     pages: [{ id: 'results', blocks: newBlocks }],
-    confetti: true,
+    confetti: !alreadyVoted,
+  };
+}
+
+function buildChatCooldownDoc(
+  doc: SnapDoc,
+  block: { title: string },
+): SnapDoc {
+  const newBlocks: Block[] = [
+    { type: 'header', title: block.title, subtitle: 'Slow down' },
+    { type: 'text', content: 'Sending too fast. Wait a few seconds and try again.' },
+  ];
+  return {
+    ...doc,
+    pages: [{ id: 'chat-cooldown', blocks: newBlocks }],
   };
 }
 

--- a/app/api/snaps/route.ts
+++ b/app/api/snaps/route.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { isKvAvailable, saveSnap } from '@/lib/kv';
 import { encodeSnap } from '@/lib/encode';
 import { validateDoc } from '@/lib/validate-snap';
+import { rateLimit, rateLimitResponse, ipOf } from '@/lib/rate-limit';
 import type { SnapDoc } from '@/lib/blocks';
+
+const SNAPS_BURST_MAX = Number(process.env.ZLANK_SNAPS_BURST_MAX ?? 5);
+const SNAPS_HOUR_MAX = Number(process.env.ZLANK_SNAPS_HOUR_MAX ?? 30);
 
 export const runtime = 'nodejs';
 
@@ -20,6 +24,13 @@ function isSnapDoc(input: unknown): input is SnapDoc {
 }
 
 export async function POST(req: NextRequest) {
+  const ip = ipOf(req);
+  const rl = await rateLimit([
+    { key: `snaps:burst:${ip}`, windowSec: 60, max: SNAPS_BURST_MAX },
+    { key: `snaps:hour:${ip}`, windowSec: 60 * 60, max: SNAPS_HOUR_MAX },
+  ]);
+  if (!rl.ok) return rateLimitResponse(rl);
+
   let body: CreateBody;
   try {
     body = (await req.json()) as CreateBody;

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -181,6 +181,17 @@ export default function Builder() {
           if (template) {
             setDoc(template.doc);
           }
+        } else {
+          // No id, no template - try to restore an in-progress draft.
+          try {
+            const raw = window.localStorage.getItem('zlank:draft:new');
+            if (raw) {
+              const parsed = JSON.parse(raw) as { doc?: SnapDoc; savedAt?: number };
+              if (parsed.doc?.version === 1) setDoc(parsed.doc);
+            }
+          } catch {
+            // ignore corrupt draft
+          }
         }
       }
     })();
@@ -393,6 +404,21 @@ export default function Builder() {
     const url = `${window.location.origin}/api/snap/${deployed}`;
     await navigator.clipboard.writeText(url);
   }
+
+  // Auto-save draft of in-progress doc to localStorage whenever it changes
+  // (debounced). Restore on next mount unless ?id= or ?template= overrode it.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const t = setTimeout(() => {
+      try {
+        const key = editingId ? `zlank:draft:edit:${editingId}` : 'zlank:draft:new';
+        window.localStorage.setItem(key, JSON.stringify({ doc, savedAt: Date.now() }));
+      } catch {
+        // localStorage full / disabled - ignore
+      }
+    }, 600);
+    return () => clearTimeout(t);
+  }, [doc, editingId]);
 
   // Cmd+S / Ctrl+S to deploy. Captured on the page (not on inputs) so the
   // browser's "save page" dialog never wins.

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -146,8 +146,25 @@ function SnapCard({ snap, onDelete }: { snap: MySnapEntry; onDelete: () => void 
           className="px-3 py-2 text-sm bg-[#1f3252] text-[#e8eef7] rounded hover:bg-[#2a3f52] transition"
           title="Copy snap URL"
         >
-          {copied ? 'Copied' : 'Share'}
+          {copied ? 'Copied' : 'Copy'}
         </button>
+        <a
+          href={(() => {
+            const url = typeof window !== 'undefined'
+              ? `${window.location.origin}/api/snap/${snap.id}`
+              : `https://zlank.online/api/snap/${snap.id}`;
+            const params = new URLSearchParams();
+            params.set('text', snap.title);
+            params.append('embeds[]', url);
+            return `https://farcaster.xyz/~/compose?${params.toString()}`;
+          })()}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="px-3 py-2 text-sm bg-[#1f3252] text-[#f5a623] rounded hover:bg-[#2a3f52] transition"
+          title="Open Farcaster composer"
+        >
+          Cast
+        </a>
         <a
           href={`/api/snap/${snap.id}`}
           target="_blank"

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -165,6 +165,42 @@ export async function recordVote(
   return out;
 }
 
+/**
+ * One-vote-per-FID-per-poll dedupe via Redis SETNX. Returns true if this is
+ * the first vote (caller should record + return tally). Returns false if the
+ * FID already voted (caller should return existing tally without bumping).
+ * Anonymous votes (fid undefined) are always permitted.
+ */
+export async function claimVote(
+  snapId: string,
+  blockIdx: number,
+  fid: number | undefined,
+): Promise<boolean> {
+  if (fid === undefined) return true;
+  const c = await getClient();
+  if (!c) return true;
+  const key = `voted:${snapId}:${blockIdx}:${fid}`;
+  const set = await c.set(key, '1', { NX: true, EX: 60 * 60 * 24 * 30 });
+  return set === 'OK';
+}
+
+/**
+ * Cooldown gate per FID per snap for chat / feedback inputs. Returns true if
+ * the call is permitted, false if rate-limited.
+ */
+export async function claimChatTurn(
+  snapId: string,
+  fid: number | undefined,
+  cooldownSec = 10,
+): Promise<boolean> {
+  if (fid === undefined) return true;
+  const c = await getClient();
+  if (!c) return true;
+  const key = `chatturn:${snapId}:${fid}`;
+  const set = await c.set(key, '1', { NX: true, EX: cooldownSec });
+  return set === 'OK';
+}
+
 export async function getVotes(
   snapId: string,
   blockIdx: number,

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,105 @@
+// Sliding-window rate limiter backed by the same Redis we use for snap state.
+// Two layers: short burst window + long sustained window. Both must pass.
+
+import { createClient, type RedisClientType } from 'redis';
+
+const HAS_REDIS = Boolean(process.env.REDIS_URL);
+let client: RedisClientType | null = null;
+let connectPromise: Promise<RedisClientType> | null = null;
+
+async function getClient(): Promise<RedisClientType | null> {
+  if (!HAS_REDIS) return null;
+  if (client?.isOpen) return client;
+  if (connectPromise) return connectPromise;
+  connectPromise = (async () => {
+    const c = createClient({ url: process.env.REDIS_URL });
+    c.on('error', (err) => console.error('rate-limit redis error', err));
+    await c.connect();
+    client = c as RedisClientType;
+    return client;
+  })();
+  try {
+    return await connectPromise;
+  } finally {
+    connectPromise = null;
+  }
+}
+
+export interface RateLimitWindow {
+  /** Redis key suffix - usually "<bucket>:<identifier>". */
+  key: string;
+  /** Window length in seconds. */
+  windowSec: number;
+  /** Max hits permitted in the window. */
+  max: number;
+}
+
+export interface RateLimitResult {
+  ok: boolean;
+  /** Hits counted including this one. */
+  count: number;
+  /** Seconds until the window resets. */
+  retryAfter: number;
+  /** Which window failed (if any). */
+  bucket?: string;
+}
+
+/**
+ * Check + increment a sliding-window counter. Uses a Redis INCR + EXPIRE NX
+ * pattern. Returns { ok: false, retryAfter } if any of the configured windows
+ * is over the cap. Fails open if Redis is unreachable.
+ */
+export async function rateLimit(windows: RateLimitWindow[]): Promise<RateLimitResult> {
+  const c = await getClient();
+  if (!c) return { ok: true, count: 0, retryAfter: 0 };
+
+  let worst: RateLimitResult = { ok: true, count: 0, retryAfter: 0 };
+  for (const w of windows) {
+    const key = `rl:${w.key}:${w.windowSec}`;
+    try {
+      const count = await c.incr(key);
+      // Set expiry only on first hit (so the window is sliding by reset, not by activity).
+      if (count === 1) await c.expire(key, w.windowSec);
+      if (count > w.max) {
+        const ttl = await c.ttl(key);
+        return {
+          ok: false,
+          count,
+          retryAfter: Math.max(1, ttl),
+          bucket: w.key,
+        };
+      }
+      if (count > worst.count) worst = { ok: true, count, retryAfter: 0 };
+    } catch {
+      // fail open per window
+    }
+  }
+  return worst;
+}
+
+/** Pull the caller's IP from common edge headers. Falls back to "unknown". */
+export function ipOf(req: Request): string {
+  const xff = req.headers.get('x-forwarded-for');
+  if (xff) return xff.split(',')[0]!.trim();
+  const real = req.headers.get('x-real-ip');
+  if (real) return real.trim();
+  return 'unknown';
+}
+
+export function rateLimitResponse(result: RateLimitResult): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'Too many requests',
+      bucket: result.bucket,
+      retryAfter: result.retryAfter,
+    }),
+    {
+      status: 429,
+      headers: {
+        'Content-Type': 'application/json',
+        'Retry-After': String(result.retryAfter),
+        'access-control-allow-origin': '*',
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Tier 2 polish. Hardens v1 against spam/abuse + adds last-mile UX so launch is real.

## What's in
1. **Rate limit** /api/snaps POST: 5/min + 30/hr per IP (env-tunable)
2. **Vote dedupe**: 1 vote per FID per poll. Subsequent votes show live tally with "Already voted" header instead of bumping. Anonymous votes always count.
3. **Chat cooldown**: 10s per FID per snap. Stops one user flooding the LLM + log.
4. **Auto-save draft** to localStorage every 600ms in builder. Restores on mount when no ?id / ?template.
5. **Cast button** on dashboard cards opens FC composer with snap URL pre-embedded + title as text.

## Skipped (already shipped)
- Live preview pane (BlockPreview already on right side of builder)
- Empty page state (already in builder)

## Test plan
- [ ] Spam POST /api/snaps from same IP -> 6th in a min returns 429 w/ Retry-After
- [ ] Vote on a poll twice from same FID -> 2nd shows "Already voted" snap, no double-count
- [ ] Submit chat 11x in 10s from same FID -> after 1st, see "Slow down" snap until cooldown
- [ ] Edit a snap in /builder, refresh tab -> draft restored
- [ ] /dashboard -> Cast button opens FC composer w/ snap URL embedded