### PR TITLE
fix(round-1): hunter pass fixes - 12 bugs (security + correctness + a11y)

### DIFF
--- a/app/api/snap/[encoded]/route.ts
+++ b/app/api/snap/[encoded]/route.ts
@@ -288,6 +288,17 @@ export async function POST(
     }
   }
 
+  // FCs are positive integers >= 1. Reject 0, negatives, non-integers - any
+  // of those means upstream lied. Drop to undefined so dedupe + gate eval
+  // treat the request as anonymous instead of attributing to a fake FID.
+  if (
+    typeof fid !== 'number' ||
+    !Number.isInteger(fid) ||
+    fid < 1
+  ) {
+    fid = undefined;
+  }
+
   const voteEntry = Object.entries(inputs).find(([k]) => k.startsWith('vote_'));
   if (voteEntry) {
     const [voteKey, voteValue] = voteEntry;
@@ -315,7 +326,7 @@ export async function POST(
   if (chatEntry) {
     const [chatKey, chatValue] = chatEntry;
     const blockIdx = Number(chatKey.replace('chat_', ''));
-    const text = String(chatValue ?? '').trim();
+    const text = String(chatValue ?? '').trim().slice(0, 240);
     if (text) {
       const targetPage = doc.pages.find((p) => p.id === (pageId || doc.pages[0]?.id));
       const block = targetPage?.blocks[blockIdx];
@@ -352,7 +363,7 @@ export async function POST(
   if (feedbackEntry) {
     const [fbKey, fbValue] = feedbackEntry;
     const blockIdx = Number(fbKey.replace('feedback_', ''));
-    const text = String(fbValue ?? '').trim();
+    const text = String(fbValue ?? '').trim().slice(0, 240);
     if (text) {
       const targetPage = doc.pages.find((p) => p.id === (pageId || doc.pages[0]?.id));
       const block = targetPage?.blocks[blockIdx];

--- a/app/api/snaps/[id]/coin/route.ts
+++ b/app/api/snaps/[id]/coin/route.ts
@@ -13,10 +13,25 @@ export const runtime = 'nodejs';
 // Allowed chain IDs: Ethereum mainnet, Base, Optimism, Polygon, Arbitrum, Zora.
 const CAIP19_RE = /^eip155:(1|8453|10|137|42161|7777777)\/erc20:0x[a-fA-F0-9]{40}$/;
 
+// AUTH: requires Authorization: Bearer <ZLANK_ADMIN_SECRET>. The builder UI
+// sets snap.coin at save time inside the SnapDoc itself, so this endpoint is
+// admin-only for now (use case: rotate/clear post-deploy without re-saving).
+// When per-FID owner auth lands, this gate flips to per-snap-owner check.
+function isAuthed(req: NextRequest): boolean {
+  const expected = process.env.ZLANK_ADMIN_SECRET;
+  if (!expected) return false;
+  const header = req.headers.get('authorization') ?? '';
+  const m = /^Bearer\s+(\S+)$/.exec(header);
+  return !!m && m[1] === expected;
+}
+
 export async function POST(
   req: NextRequest,
   ctx: { params: Promise<{ id: string }> },
 ) {
+  if (!isAuthed(req)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
   const { id } = await ctx.params;
   let body: { caip19?: string; symbol?: string; clear?: boolean };
   try {

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { put } from '@vercel/blob';
 import { nanoid } from 'nanoid';
+import { rateLimit, rateLimitResponse, ipOf } from '@/lib/rate-limit';
 
 export const runtime = 'nodejs';
 
@@ -11,7 +12,17 @@ export const runtime = 'nodejs';
 const MAX_BYTES = 4 * 1024 * 1024; // 4 MiB
 const ALLOWED = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
 
+const UPLOAD_BURST_MAX = Number(process.env.ZLANK_UPLOAD_BURST_MAX ?? 10);
+const UPLOAD_HOUR_MAX = Number(process.env.ZLANK_UPLOAD_HOUR_MAX ?? 60);
+
 export async function POST(req: NextRequest) {
+  const ip = ipOf(req);
+  const rl = await rateLimit([
+    { key: `upload:burst:${ip}`, windowSec: 60, max: UPLOAD_BURST_MAX },
+    { key: `upload:hour:${ip}`, windowSec: 60 * 60, max: UPLOAD_HOUR_MAX },
+  ]);
+  if (!rl.ok) return rateLimitResponse(rl);
+
   if (!process.env.BLOB_READ_WRITE_TOKEN) {
     return NextResponse.json(
       { error: 'Image upload disabled - BLOB_READ_WRITE_TOKEN not set on server.' },

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -164,17 +164,33 @@ export default function Builder() {
         const templateId = params.get('template');
 
         if (snapId) {
-          // Load existing snap for editing
+          // Load existing snap for editing. Then check for an in-progress
+          // edit draft (autosave key zlank:draft:edit:{id}); if it's newer
+          // than the server doc and the user wants it back, prefer the draft.
+          // For now, load draft silently if present - the autosave window is
+          // 600ms so anything in localStorage is by definition "newest".
+          setEditingId(snapId);
+          let serverDoc: SnapDoc | null = null;
           try {
             const res = await fetch(`/api/snaps/${snapId}/doc`);
-            if (res.ok) {
-              const loaded = (await res.json()) as SnapDoc;
-              setDoc(loaded);
-              setEditingId(snapId);
+            if (res.ok) serverDoc = (await res.json()) as SnapDoc;
+          } catch {
+            // ignore - we'll try draft below
+          }
+          let restored = false;
+          try {
+            const raw = window.localStorage.getItem(`zlank:draft:edit:${snapId}`);
+            if (raw) {
+              const parsed = JSON.parse(raw) as { doc?: SnapDoc; savedAt?: number };
+              if (parsed.doc?.version === 1) {
+                setDoc(parsed.doc);
+                restored = true;
+              }
             }
           } catch {
-            // silently fail, stay with default
+            // corrupt draft - fall through to server
           }
+          if (!restored && serverDoc) setDoc(serverDoc);
         } else if (templateId) {
           // Load template
           const template = getTemplateById(templateId);
@@ -631,12 +647,13 @@ export default function Builder() {
 
           <div className="border-t border-[#1f3252] pt-3 space-y-2">
             <h3 className="text-xs text-[#8aa0bd] uppercase tracking-wide">Add block</h3>
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
               {BLOCK_OPTIONS.map((opt) => (
                 <button
                   key={opt.type}
                   onClick={() => addBlock(opt.type)}
-                  className="bg-[#122440] border border-[#1f3252] rounded px-2 py-3 text-xs hover:border-[#f5a623] transition"
+                  aria-label={`Add ${opt.label} block`}
+                  className="bg-[#122440] border border-[#1f3252] rounded px-3 py-3 text-xs hover:border-[#f5a623] transition min-h-[56px]"
                 >
                   <div className="font-bold text-[#f5a623]">{opt.icon}</div>
                   <div className="mt-1">{opt.label}</div>
@@ -739,7 +756,14 @@ function BlockEditor({
       )}
       <div className="flex items-center justify-between gap-2">
         <span className="text-xs text-[#f5a623] uppercase flex items-center gap-1">
-          <span className="cursor-grab text-[#5e7290]" title="Drag to reorder">::</span>
+          <span
+            className="cursor-grab text-[#5e7290]"
+            aria-label="Drag handle - press up or dn buttons on touch devices"
+            title="Drag to reorder (use up/dn buttons on mobile)"
+            role="img"
+          >
+            ::
+          </span>
           {block.type}
         </span>
         <div className="flex gap-1 text-xs">

--- a/lib/validate-snap.ts
+++ b/lib/validate-snap.ts
@@ -17,7 +17,7 @@ function lintBlock(block: Block, idx: number, pageBlocks: Block[]): string[] {
       break;
     case 'link':
       if (!block.label?.trim()) issues.push(`${here}: link label is empty`);
-      if (!/^https?:\/\//.test(block.url)) issues.push(`${here}: link url must start with https://`);
+      if (!/^https:\/\//.test(block.url)) issues.push(`${here}: link url must start with https://`);
       break;
     case 'share':
       if (!block.label?.trim()) issues.push(`${here}: share label is empty`);
@@ -25,10 +25,13 @@ function lintBlock(block: Block, idx: number, pageBlocks: Block[]): string[] {
       break;
     case 'image':
       if (!block.url?.trim()) issues.push(`${here}: image url is empty`);
+      else if (!/^https:\/\//.test(block.url)) {
+        issues.push(`${here}: image url must start with https:// (got ${block.url.slice(0, 20)}...)`);
+      }
       break;
     case 'music':
       if (!block.url?.trim()) issues.push(`${here}: music url is empty`);
-      if (!/^https?:\/\//.test(block.url)) issues.push(`${here}: music url must start with https://`);
+      else if (!/^https:\/\//.test(block.url)) issues.push(`${here}: music url must start with https://`);
       break;
     case 'artist':
       if (!Number.isFinite(block.fid) || block.fid <= 0) {
@@ -122,6 +125,16 @@ export function validateDoc(doc: SnapDoc, baseUrl = 'https://zlank.online/api/sn
   const pages: ValidatePageResult[] = [];
   const errors: string[] = [];
 
+  // Doc-level lint: page IDs are required + unique; navigate targets must
+  // resolve to a real page on this doc.
+  const seenPageIds = new Set<string>();
+  const knownPageIds = new Set(doc.pages.map((p) => p.id));
+  for (const page of doc.pages) {
+    if (!page.id?.trim()) errors.push(`page id is empty`);
+    else if (seenPageIds.has(page.id)) errors.push(`page id "${page.id}" is duplicated`);
+    seenPageIds.add(page.id);
+  }
+
   for (const page of doc.pages) {
     const issues: string[] = [];
 
@@ -129,6 +142,11 @@ export function validateDoc(doc: SnapDoc, baseUrl = 'https://zlank.online/api/sn
     // snap-spec.ts handles them at render time).
     page.blocks.forEach((block, idx) => {
       issues.push(...lintBlock(block, idx, page.blocks));
+      if (block.type === 'navigate' && block.pageId && !knownPageIds.has(block.pageId)) {
+        issues.push(
+          `block ${idx} (navigate): pageId "${block.pageId}" does not exist (known: ${[...knownPageIds].join(', ')})`,
+        );
+      }
     });
 
     let snap: unknown;

--- a/scripts/audit-templates.ts
+++ b/scripts/audit-templates.ts
@@ -15,7 +15,26 @@ const PLACEHOLDER_URL_HOSTS = ['example.com', 'example.org'];
 const GENERIC_LABEL_RE = /^(Option [A-Z0-9]+|Statement \d+|Artist \d+|Choice \d+)$/i;
 const TRUNCATED_URL_RE = /\/(track|playlist|album|user)\/$/;
 
+// Detect unsubstituted template-var residue like "{snap-id}" or "{userFid}".
+const TEMPLATE_VAR_RE = /\{[a-zA-Z][\w-]*\}/;
+
 const UX_RULES: WarnRule[] = [
+  (b) => {
+    // Scan every string-valued field on the block for template-var residue.
+    const fields: string[] = [];
+    if ('content' in b && typeof b.content === 'string') fields.push(b.content);
+    if ('title' in b && typeof b.title === 'string') fields.push(b.title);
+    if ('subtitle' in b && typeof b.subtitle === 'string') fields.push(b.subtitle);
+    if ('label' in b && typeof b.label === 'string') fields.push(b.label);
+    if ('prompt' in b && typeof b.prompt === 'string') fields.push(b.prompt);
+    if ('text' in b && typeof b.text === 'string') fields.push(b.text);
+    if ('placeholder' in b && typeof b.placeholder === 'string') fields.push(b.placeholder);
+    for (const f of fields) {
+      const m = TEMPLATE_VAR_RE.exec(f);
+      if (m) return `unsubstituted template var "${m[0]}" in: ${f.slice(0, 60)}`;
+    }
+    return null;
+  },
   (b) => {
     if ('url' in b && typeof b.url === 'string') {
       try {


### PR DESCRIPTION
5 parallel hunters returned 26 candidates. 6 verified false positives, 12 real shipped here, 2 deferred (iOS DnD polyfill, contrast bump - bigger refactors).

## Security
- Coin endpoint auth gate (was wide open - any caller could rewrite Buy button)
- Upload rate limit (was unbounded - quota drain risk)
- Image url https-only (was unchecked - data: + javascript: XSS risk)
- Link/music url tightened to https only (was https?:)

## Correctness
- Edit-draft restore (writing to localStorage but never reading on ?id=)
- Server-side maxLength on chat + feedback (was unbounded)
- FID 0/negative coerced to undefined
- Doc-level lint: duplicate + empty page IDs
- navigate.pageId must point at a real page
- Audit detects unsubstituted {snap-id}-style template-var residue

## A11y/Mobile
- Drag handle aria-label + role + iOS-friendly title hint
- Block picker: grid-cols-2 on mobile, min-h-[56px], aria-labels - meets WCAG 44x44

## Verified false positives (didn't ship)
Cmd+S 'stale closure', empty-state JSX precedence, duplicate-on-empty, badgeText clamp, toggle >6 - all already handled correctly elsewhere.

11/11 templates still pass post-changes.