### PR TITLE
feat(auth): owner FID auth + per-FID upload cap

### DIFF
--- a/app/api/snaps/[id]/coin/route.ts
+++ b/app/api/snaps/[id]/coin/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { setSnapCoin } from '@/lib/kv';
+import { authorizeOwner } from '@/lib/auth';
 
 export const runtime = 'nodejs';
 
@@ -7,32 +8,31 @@ export const runtime = 'nodejs';
 // Body: { caip19: "eip155:8453/erc20:0x...", symbol?: "MYTOKEN" }
 // or:   { clear: true } to remove the coin association.
 //
-// Updates BOTH the runtime snap key and the editable snapdoc key in Redis
-// so the swap_token button auto-injects on next render.
+// AUTH (in order):
+//  1. Authorization: Bearer <ZLANK_ADMIN_SECRET> - admin bypass
+//  2. Authorization: Bearer <quickAuth JWT> where the JWT's FID matches the
+//     snap's stored owner (set at save time)
+//  3. If snap has no owner yet (legacy or unowned), the first valid FID
+//     to call this endpoint claims ownership.
+//
+// Anonymous callers and FID-mismatch callers get 401.
 
 // Allowed chain IDs: Ethereum mainnet, Base, Optimism, Polygon, Arbitrum, Zora.
 const CAIP19_RE = /^eip155:(1|8453|10|137|42161|7777777)\/erc20:0x[a-fA-F0-9]{40}$/;
-
-// AUTH: requires Authorization: Bearer <ZLANK_ADMIN_SECRET>. The builder UI
-// sets snap.coin at save time inside the SnapDoc itself, so this endpoint is
-// admin-only for now (use case: rotate/clear post-deploy without re-saving).
-// When per-FID owner auth lands, this gate flips to per-snap-owner check.
-function isAuthed(req: NextRequest): boolean {
-  const expected = process.env.ZLANK_ADMIN_SECRET;
-  if (!expected) return false;
-  const header = req.headers.get('authorization') ?? '';
-  const m = /^Bearer\s+(\S+)$/.exec(header);
-  return !!m && m[1] === expected;
-}
 
 export async function POST(
   req: NextRequest,
   ctx: { params: Promise<{ id: string }> },
 ) {
-  if (!isAuthed(req)) {
-    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-  }
   const { id } = await ctx.params;
+  const auth = await authorizeOwner(id, req);
+  if (!auth.ok) {
+    return NextResponse.json(
+      { error: 'unauthorized', reason: auth.reason },
+      { status: 401 },
+    );
+  }
+
   let body: { caip19?: string; symbol?: string; clear?: boolean };
   try {
     body = (await req.json()) as typeof body;
@@ -44,7 +44,7 @@ export async function POST(
     const r = await setSnapCoin(id, null);
     if (r.missing) return NextResponse.json({ error: 'snap not found' }, { status: 404 });
     if (r.updated === 0) return NextResponse.json({ error: 'snap corrupt' }, { status: 500 });
-    return NextResponse.json({ ok: true, cleared: true, updated: r.updated });
+    return NextResponse.json({ ok: true, cleared: true, updated: r.updated, via: auth.via });
   }
 
   const caip19 = body.caip19?.trim();
@@ -61,5 +61,10 @@ export async function POST(
   const r = await setSnapCoin(id, { caip19, symbol });
   if (r.missing) return NextResponse.json({ error: 'snap not found' }, { status: 404 });
   if (r.updated === 0) return NextResponse.json({ error: 'snap corrupt' }, { status: 500 });
-  return NextResponse.json({ ok: true, updated: r.updated, coin: { caip19, symbol } });
+  return NextResponse.json({
+    ok: true,
+    updated: r.updated,
+    coin: { caip19, symbol },
+    via: auth.via,
+  });
 }

--- a/app/api/snaps/route.ts
+++ b/app/api/snaps/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { isKvAvailable, saveSnap } from '@/lib/kv';
+import { isKvAvailable, saveSnap, claimSnapOwner } from '@/lib/kv';
 import { encodeSnap } from '@/lib/encode';
 import { validateDoc } from '@/lib/validate-snap';
 import { rateLimit, rateLimitResponse, ipOf } from '@/lib/rate-limit';
+import { extractFid } from '@/lib/auth';
 import type { SnapDoc } from '@/lib/blocks';
 
 const SNAPS_BURST_MAX = Number(process.env.ZLANK_SNAPS_BURST_MAX ?? 5);
@@ -66,7 +67,16 @@ export async function POST(req: NextRequest) {
 
   try {
     const id = await saveSnap(body.doc);
-    return NextResponse.json({ id, short: true });
+    // Capture owner FID at save time when caller presents a valid Quick Auth
+    // JWT (Mini App context). Browser-only callers (no token) leave the snap
+    // unowned; first authenticated caller to /coin can claim it.
+    const fid = await extractFid(req);
+    if (fid) {
+      await claimSnapOwner(id, fid).catch((err) =>
+        console.error('claimSnapOwner failed', id, err),
+      );
+    }
+    return NextResponse.json({ id, short: true, owner: fid ?? null });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : 'Unknown error';
     return NextResponse.json({ error: 'Failed to save snap', detail: msg }, { status: 500 });

--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { put } from '@vercel/blob';
 import { nanoid } from 'nanoid';
 import { rateLimit, rateLimitResponse, ipOf } from '@/lib/rate-limit';
+import { extractFid } from '@/lib/auth';
 
 export const runtime = 'nodejs';
 
@@ -14,13 +15,25 @@ const ALLOWED = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'];
 
 const UPLOAD_BURST_MAX = Number(process.env.ZLANK_UPLOAD_BURST_MAX ?? 10);
 const UPLOAD_HOUR_MAX = Number(process.env.ZLANK_UPLOAD_HOUR_MAX ?? 60);
+const UPLOAD_PER_FID_DAY_MAX = Number(process.env.ZLANK_UPLOAD_FID_DAY_MAX ?? 50);
 
 export async function POST(req: NextRequest) {
   const ip = ipOf(req);
-  const rl = await rateLimit([
+  const fid = await extractFid(req);
+  const limits = [
     { key: `upload:burst:${ip}`, windowSec: 60, max: UPLOAD_BURST_MAX },
     { key: `upload:hour:${ip}`, windowSec: 60 * 60, max: UPLOAD_HOUR_MAX },
-  ]);
+  ];
+  if (fid) {
+    // Authenticated callers get a per-FID daily cap on top of the IP windows.
+    // Stops a single account from filling Blob via residential-proxy IP rotation.
+    limits.push({
+      key: `upload:fid:${fid}:day`,
+      windowSec: 60 * 60 * 24,
+      max: UPLOAD_PER_FID_DAY_MAX,
+    });
+  }
+  const rl = await rateLimit(limits);
   if (!rl.ok) return rateLimitResponse(rl);
 
   if (!process.env.BLOB_READ_WRITE_TOKEN) {

--- a/app/builder/page.tsx
+++ b/app/builder/page.tsx
@@ -351,9 +351,21 @@ export default function Builder() {
     setDeployErr(null);
     setValidationIssues([]);
     try {
+      // In Mini App context, attach a Quick Auth JWT so the server can record
+      // the creator's FID as the snap's owner. Browser-only callers skip the
+      // token; their snaps stay unowned until first authenticated /coin call.
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (isMiniApp) {
+        try {
+          const { token } = await sdk.quickAuth.getToken();
+          if (token) headers.authorization = `Bearer ${token}`;
+        } catch {
+          // continue without owner attribution if token fetch fails
+        }
+      }
       const res = await fetch('/api/snaps', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({ doc }),
       });
       if (!res.ok) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,78 @@
+import { createClient } from '@farcaster/quick-auth';
+import { getSnapOwner, claimSnapOwner } from './kv';
+
+const client = createClient();
+
+const QUICK_AUTH_DOMAIN = process.env.ZLANK_QUICK_AUTH_DOMAIN || 'zlank.online';
+
+/**
+ * Extract the caller's Farcaster FID from a request.
+ *
+ * Reads the `Authorization: Bearer <token>` header (Farcaster Quick Auth JWT
+ * issued by the Mini App SDK). Verifies the token's signature against the
+ * Farcaster auth server's JWKS. Returns the FID on success, undefined otherwise.
+ *
+ * Returns undefined silently for missing/invalid tokens so callers can decide
+ * whether to fail open (read-only routes) or fail closed (write routes).
+ */
+export async function extractFid(req: Request): Promise<number | undefined> {
+  const authHeader = req.headers.get('authorization') ?? '';
+  const m = /^Bearer\s+(\S+)$/.exec(authHeader);
+  if (!m) return undefined;
+  const token = m[1];
+  try {
+    const result = await client.verifyJwt({ token, domain: QUICK_AUTH_DOMAIN });
+    const fid = result.sub;
+    if (typeof fid === 'number' && Number.isInteger(fid) && fid >= 1) {
+      return fid;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** True if the caller presented the admin shared secret. */
+export function isAdmin(req: Request): boolean {
+  const expected = process.env.ZLANK_ADMIN_SECRET;
+  if (!expected) return false;
+  const header = req.headers.get('authorization') ?? '';
+  const m = /^Bearer\s+(\S+)$/.exec(header);
+  return !!m && m[1] === expected;
+}
+
+export type AuthResult =
+  | { ok: true; via: 'admin' | 'owner' | 'first-claim'; fid?: number }
+  | { ok: false; reason: 'no_token' | 'invalid_token' | 'not_owner'; fid?: number };
+
+/**
+ * Authorize a caller to perform an owner-level action on a snap.
+ *
+ * Order of checks:
+ *  1. Admin secret bypass (legacy snaps + ops use)
+ *  2. Owner FID match (snap has stored owner = caller's FID)
+ *  3. First-claim wins (snap has no owner, caller's FID becomes owner)
+ *
+ * Anonymous + non-owner callers get { ok: false, reason }.
+ */
+export async function authorizeOwner(snapId: string, req: Request): Promise<AuthResult> {
+  if (isAdmin(req)) return { ok: true, via: 'admin' };
+
+  const fid = await extractFid(req);
+  if (!fid) {
+    const header = req.headers.get('authorization') ?? '';
+    return {
+      ok: false,
+      reason: header ? 'invalid_token' : 'no_token',
+    };
+  }
+
+  const owner = await getSnapOwner(snapId);
+  if (owner === null) {
+    // Snap has no owner yet (legacy or just-created). First valid FID claims it.
+    await claimSnapOwner(snapId, fid);
+    return { ok: true, via: 'first-claim', fid };
+  }
+  if (owner === fid) return { ok: true, via: 'owner', fid };
+  return { ok: false, reason: 'not_owner', fid };
+}

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -139,6 +139,33 @@ export async function loadSnapDoc(id: string): Promise<SnapDoc | null> {
   }
 }
 
+const OWNER_PREFIX = 'owner:';
+
+/**
+ * Owner FID for a saved snap. Stored separately from the SnapDoc so older
+ * snaps without an owner key remain readable + claimable. null = no owner
+ * recorded; undefined never (we treat absence as null).
+ */
+export async function getSnapOwner(snapId: string): Promise<number | null> {
+  const c = await getClient();
+  if (!c) return null;
+  const raw = await c.get(OWNER_PREFIX + snapId);
+  if (!raw) return null;
+  const fid = Number(raw);
+  return Number.isInteger(fid) && fid >= 1 ? fid : null;
+}
+
+/**
+ * Set an owner FID for a snap if (and only if) none is set yet (NX). Returns
+ * true if this call became the owner, false if someone else already owns it.
+ */
+export async function claimSnapOwner(snapId: string, fid: number): Promise<boolean> {
+  const c = await getClient();
+  if (!c) return false;
+  const set = await c.set(OWNER_PREFIX + snapId, String(fid), { NX: true });
+  return set === 'OK';
+}
+
 /**
  * Generic short-lived cache (gate evaluations, Neynar lookups, etc.).
  * Returns null on cache miss or Redis unreachable. Caller falls back to fresh.


### PR DESCRIPTION
Closes the deferred R2 security item. Snaps capture creator FID at save time via @farcaster/quick-auth JWT; coin endpoint authorizes per-owner instead of admin-only.

## Changes
- new lib/auth.ts with extractFid + isAdmin + authorizeOwner
- new lib/kv.ts owner helpers (getSnapOwner, claimSnapOwner via SETNX)
- /api/snaps POST captures owner FID when token present, returns owner in response
- /api/snaps/[id]/coin uses authorizeOwner (3-tier: admin / owner-match / first-claim)
- /api/upload adds per-FID 50/day cap on top of IP windows
- builder deploy() sends sdk.quickAuth.getToken() as Authorization header in Mini App context

## Migration
Existing snaps have no owner. First authenticated /coin caller claims ownership. Admin secret still bypasses for ops.

## Env (all optional)
- ZLANK_QUICK_AUTH_DOMAIN (default zlank.online)
- ZLANK_UPLOAD_FID_DAY_MAX (default 50)

## Test plan
- [ ] Save a snap from /builder in browser (no token) -> response has owner: null
- [ ] Save a snap from FC Mini App -> response has owner: <your FID>; Redis owner:{id} key set
- [ ] POST /coin without auth header -> 401 reason: no_token
- [ ] POST /coin with admin Bearer -> 200 via: admin
- [ ] POST /coin with valid JWT matching owner -> 200 via: owner
- [ ] POST /coin with valid JWT NOT matching owner -> 401 reason: not_owner
- [ ] POST /coin on legacy snap with valid JWT -> 200 via: first-claim (owner now set)